### PR TITLE
Implement support for the `subtle.generateKey` operation

### DIFF
--- a/examples/generate-key.js
+++ b/examples/generate-key.js
@@ -1,0 +1,12 @@
+import { crypto } from "k6/x/webcrypto";
+
+export default function () {
+  crypto.subtle
+    .generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+      "sign",
+      "verify",
+    ])
+    .then((key) => {
+      console.log(JSON.stringify(key));
+    });
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/xk6-webcrypto
 
-go 1.19
+go 1.18
 
 require (
 	github.com/dop251/goja v0.0.0-20220815083517-0c74f9139fd6

--- a/testdata/scripts/assert.js
+++ b/testdata/scripts/assert.js
@@ -1,0 +1,21 @@
+function assert_equals(actual, expected, description) {
+  if (actual !== expected) {
+    throw `assert_equals ${description} expected (${typeof expected}) ${expected} but got (${typeof actual}) ${actual}`;
+  }
+}
+
+function assert_not_equals(actual, expected, description) {
+  if (actual === expected) {
+    throw `assert_not_equals ${description} got disallowed value ${actual}`;
+  }
+}
+
+function assert_in_array(actual, expected, description) {
+  if (expected.indexOf(actual) === -1) {
+    throw `assert_in_array ${description} value ${actual} not in array ${expected}`;
+  }
+}
+
+function assert_unreached(description) {
+  throw `assert_unreached ${description}`;
+}

--- a/testdata/scripts/helpers.js
+++ b/testdata/scripts/helpers.js
@@ -1,0 +1,345 @@
+//
+// helpers.js
+//
+// Helper functions used by several WebCryptoAPI tests
+//
+
+var registeredAlgorithmNames = [
+  "RSASSA-PKCS1-v1_5",
+  "RSA-PSS",
+  "RSA-OAEP",
+  "ECDSA",
+  "ECDH",
+  "AES-CTR",
+  "AES-CBC",
+  "AES-GCM",
+  "AES-KW",
+  "HMAC",
+  "SHA-1",
+  "SHA-256",
+  "SHA-384",
+  "SHA-512",
+  "HKDF-CTR",
+  "PBKDF2",
+  "Ed25519",
+  "Ed448",
+  "X25519",
+  "X448",
+];
+
+// Don't create an exhaustive list of all invalid usages,
+// because there would usually be nearly 2**8 of them,
+// way too many to test. Instead, create every singleton
+// of an illegal usage, and "poison" every valid usage
+// with an illegal one.
+function invalidUsages(validUsages, mandatoryUsages) {
+  var results = [];
+
+  var illegalUsages = [];
+  [
+    "encrypt",
+    "decrypt",
+    "sign",
+    "verify",
+    "wrapKey",
+    "unwrapKey",
+    "deriveKey",
+    "deriveBits",
+  ].forEach(function (usage) {
+    if (!validUsages.includes(usage)) {
+      illegalUsages.push(usage);
+    }
+  });
+
+  var goodUsageCombinations = allValidUsages(
+    validUsages,
+    false,
+    mandatoryUsages
+  );
+
+  illegalUsages.forEach(function (illegalUsage) {
+    results.push([illegalUsage]);
+    goodUsageCombinations.forEach(function (usageCombination) {
+      results.push(usageCombination.concat([illegalUsage]));
+    });
+  });
+
+  return results;
+}
+
+// Algorithm name specifiers are case-insensitive. Generate several
+// case variations of a given name.
+function allNameVariants(name) {
+  var upCaseName = name.toUpperCase();
+  var lowCaseName = name.toLowerCase();
+  var mixedCaseName = upCaseName.substring(0, 1) + lowCaseName.substring(1);
+
+  return unique([upCaseName, lowCaseName, mixedCaseName, name]);
+}
+
+function allValidUsages(validUsages, allowEmpty, mandatoryUsages) {
+  if (typeof mandatoryUsages === "undefined") {
+    mandatoryUsages = [];
+  }
+
+  var okaySubsets = [];
+  allNonemptySubsetsOf(validUsages).forEach((subset) => {
+    if (mandatoryUsages.length === 0) {
+      okaySubsets.push(subset);
+    } else {
+      for (var i = 0; i < mandatoryUsages.length; i++) {
+        if (subset.includes(mandatoryUsages[i])) {
+          okaySubsets.push(subset);
+          return;
+        }
+      }
+    }
+  });
+
+  if (allowEmpty) {
+    okaySubsets.push([]);
+  }
+
+  okaySubsets.push(validUsages.concat(mandatoryUsages).concat(validUsages));
+  return okaySubsets;
+}
+
+// Treats an array as a set, and generates an array of all non-empty
+// subsets (which are themselves arrays).
+//
+// The order of members of the "subsets" is not guaranteed.
+function allNonemptySubsetsOf(arr) {
+  var results = [];
+  var firstElement;
+  var remainingElements;
+
+  for (var i = 0; i < arr.length; i++) {
+    firstElement = arr[i];
+    remainingElements = arr.slice(i + 1);
+    results.push([firstElement]);
+
+    if (remainingElements.length > 0) {
+      allNonemptySubsetsOf(remainingElements).forEach(function (combination) {
+        combination.push(firstElement);
+        results.push(combination);
+      });
+    }
+  }
+
+  return results;
+}
+
+function unique(names) {
+  return [...new Set(names)];
+}
+
+/**
+ * @class
+ * Exception type that represents a failing assert.
+ *
+ * @param {string} message - Error message.
+ */
+function AssertionError(message) {
+  if (typeof message == "string") {
+    message = sanitize_unpaired_surrogates(message);
+  }
+  this.message = message;
+  this.stack = get_stack();
+}
+/*
+ * Utility functions
+ */
+function assert(
+  expected_true,
+  function_name,
+  description,
+  error,
+  substitutions
+) {
+  if (expected_true !== true) {
+    var msg = `${function_name}, ${description}, ${error}, ${substitutions}`;
+    throw new AssertionError(msg);
+  }
+}
+
+/**
+ * Assert that ``actual`` is the same value as ``expected``.
+ *
+ * For objects this compares by cobject identity; for primitives
+ * this distinguishes between 0 and -0, and has correct handling
+ * of NaN.
+ *
+ * @param {Any} actual - Test value.
+ * @param {Any} expected - Expected value.
+ * @param {string} [description] - Description of the condition being tested.
+ */
+function assert_equals(actual, expected, description) {
+  /*
+   * Test if two primitives are equal or two objects
+   * are the same object
+   */
+  if (typeof actual != typeof expected) {
+    assert(
+      false,
+      "assert_equals",
+      description,
+      "expected (" +
+        typeof expected +
+        ") ${expected} but got (" +
+        typeof actual +
+        ") ${actual}",
+      { expected: expected, actual: actual }
+    );
+    return;
+  }
+  assert(
+    same_value(actual, expected),
+    "assert_equals",
+    description,
+    "expected ${expected} but got ${actual}",
+    { expected: expected, actual: actual }
+  );
+}
+
+// Is key a CryptoKey object with correct algorithm, extractable, and usages?
+// Is it a secret, private, or public kind of key?
+function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
+  var correctUsages = [];
+
+  var registeredAlgorithmName;
+  registeredAlgorithmNames.forEach(function (name) {
+    if (name.toUpperCase() === algorithm.name.toUpperCase()) {
+      registeredAlgorithmName = name;
+    }
+  });
+
+  assert_equals(key.constructor, CryptoKey, "Is a CryptoKey");
+  assert_equals(key.type, kind, "Is a " + kind + " key");
+  if (key.type === "public") {
+    extractable = true; // public keys are always extractable
+  }
+  assert_equals(key.extractable, extractable, "Extractability is correct");
+
+  assert_equals(
+    key.algorithm.name,
+    registeredAlgorithmName,
+    "Correct algorithm name"
+  );
+  if (
+    key.algorithm.name.toUpperCase() === "HMAC" &&
+    algorithm.length === undefined
+  ) {
+    switch (key.algorithm.hash.name.toUpperCase()) {
+      case "SHA-1":
+      case "SHA-256":
+        assert_equals(key.algorithm.length, 512, "Correct length");
+        break;
+      case "SHA-384":
+      case "SHA-512":
+        assert_equals(key.algorithm.length, 1024, "Correct length");
+        break;
+      default:
+        assert_unreached("Unrecognized hash");
+    }
+  } else {
+    assert_equals(key.algorithm.length, algorithm.length, "Correct length");
+  }
+  if (
+    ["HMAC", "RSASSA-PKCS1-v1_5", "RSA-PSS"].includes(registeredAlgorithmName)
+  ) {
+    assert_equals(
+      key.algorithm.hash.name.toUpperCase(),
+      algorithm.hash.toUpperCase(),
+      "Correct hash function"
+    );
+  }
+
+  // usages is expected to be provided for a key pair, but we are checking
+  // only a single key. The publicKey and privateKey portions of a key pair
+  // recognize only some of the usages appropriate for a key pair.
+  if (key.type === "public") {
+    ["encrypt", "verify", "wrapKey"].forEach(function (usage) {
+      if (usages.includes(usage)) {
+        correctUsages.push(usage);
+      }
+    });
+  } else if (key.type === "private") {
+    ["decrypt", "sign", "unwrapKey", "deriveKey", "deriveBits"].forEach(
+      function (usage) {
+        if (usages.includes(usage)) {
+          correctUsages.push(usage);
+        }
+      }
+    );
+  } else {
+    correctUsages = usages;
+  }
+
+  assert_equals(
+    typeof key.usages,
+    "object",
+    key.type + " key.usages is an object"
+  );
+  assert_not_equals(key.usages, null, key.type + " key.usages isn't null");
+
+  // The usages parameter could have repeats, but the usages
+  // property of the result should not.
+  var usageCount = 0;
+  key.usages.forEach(function (usage) {
+    usageCount += 1;
+    assert_in_array(usage, correctUsages, "Has " + usage + " usage");
+  });
+  assert_equals(key.usages.length, usageCount, "usages property is correct");
+}
+
+// The algorithm parameter is an object with a name and other
+// properties. Given the name, generate all valid parameters.
+function allAlgorithmSpecifiersFor(algorithmName) {
+  var results = [];
+
+  // RSA key generation is slow. Test a minimal set of parameters
+  var hashes = ["SHA-1", "SHA-256"];
+
+  // EC key generation is a lot faster. Check all curves in the spec
+  var curves = ["P-256", "P-384", "P-521"];
+
+  if (algorithmName.toUpperCase().substring(0, 3) === "AES") {
+    // Specifier properties are name and length
+    [128, 192, 256].forEach(function (length) {
+      results.push({ name: algorithmName, length: length });
+    });
+  } else if (algorithmName.toUpperCase() === "HMAC") {
+    [
+      { hash: "SHA-1", length: 160 },
+      { hash: "SHA-256", length: 256 },
+      { hash: "SHA-384", length: 384 },
+      { hash: "SHA-512", length: 512 },
+      { hash: "SHA-1" },
+      { hash: "SHA-256" },
+      { hash: "SHA-384" },
+      { hash: "SHA-512" },
+    ].forEach(function (hashAlgorithm) {
+      results.push({ name: algorithmName, ...hashAlgorithm });
+    });
+  } else if (algorithmName.toUpperCase().substring(0, 3) === "RSA") {
+    hashes.forEach(function (hashName) {
+      results.push({
+        name: algorithmName,
+        hash: hashName,
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+      });
+    });
+  } else if (algorithmName.toUpperCase().substring(0, 2) === "EC") {
+    curves.forEach(function (curveName) {
+      results.push({ name: algorithmName, namedCurve: curveName });
+    });
+  } else if (
+    algorithmName.toUpperCase().substring(0, 1) === "X" ||
+    algorithmName.toUpperCase().substring(0, 2) === "ED"
+  ) {
+    results.push({ name: algorithmName });
+  }
+
+  return results;
+}

--- a/webcrypto/aes.go
+++ b/webcrypto/aes.go
@@ -1,0 +1,146 @@
+package webcrypto
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+// AesKeyAlgorithm represents the AES algorithm.
+type AesKeyAlgorithm struct {
+	KeyAlgorithm
+
+	// The length, in bits, of the key.
+	Length int `json:"length"`
+}
+
+// AESKeyGenParams represents the object that should be passed as
+// the algorithm parameter into `SubtleCrypto.generateKey`, when generating
+// an AES key: that is, when the algorithm is identified as any
+// of AES-CBC, AES-CTR, AES-GCM, or AES-KW.
+type AesKeyGenParams struct {
+	Algorithm
+
+	// Length holds (a Number) the length of the key, in bits.
+	Length int `json:"length"`
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ From[map[string]interface{}, AesKeyGenParams] = AesKeyGenParams{}
+
+// From fills the AesKeyGenParams from the given dictionary object.
+func (a AesKeyGenParams) From(dict map[string]interface{}) (AesKeyGenParams, error) {
+	nameFound := false
+	lengthFound := false
+
+	for key, value := range dict {
+		if strings.EqualFold(key, "name") {
+			name, ok := value.(string)
+			if !ok {
+				return AesKeyGenParams{}, NewError(0, SyntaxError, "name property should hold a string")
+			}
+
+			name = strings.ToUpper(name)
+
+			if !IsAlgorithm(name) {
+				return AesKeyGenParams{}, NewError(0, NotSupportedError, fmt.Sprintf("algorithm %s is not supported", name))
+			}
+
+			a.Name = AlgorithmIdentifier(name)
+			nameFound = true
+			continue
+		}
+
+		if strings.EqualFold(key, "length") {
+			length, ok := value.(int64)
+			if !ok {
+				return AesKeyGenParams{}, NewError(0, SyntaxError, "length property should hold a number")
+			}
+
+			a.Length = int(length)
+			lengthFound = true
+			continue
+		}
+	}
+
+	if !nameFound {
+		return AesKeyGenParams{}, NewError(0, SyntaxError, "name property is required")
+	}
+
+	if !lengthFound {
+		return AesKeyGenParams{}, NewError(0, SyntaxError, "length property is required")
+	}
+
+	return a, nil
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ KeyGenerator = &AesKeyGenParams{}
+
+// GenerateKey generates a new AES key.
+func (a *AesKeyGenParams) GenerateKey(rt *goja.Runtime, extractable bool, keyUsages []CryptoKeyUsage) (goja.Value, error) {
+	if a.Algorithm.Name != AESCbc && a.Algorithm.Name != AESCtr && a.Algorithm.Name != AESGcm && a.Algorithm.Name != AESKw {
+		return nil, NewError(0, ImplementationError, "invalid algorithm")
+	}
+
+	// 1.
+	for _, usage := range keyUsages {
+		if strings.EqualFold(string(a.Algorithm.Name), AESKw) {
+			switch usage {
+			case WrapKeyCryptoKeyUsage, UnwrapKeyCryptoKeyUsage:
+			default:
+				return nil, NewError(0, SyntaxError, "invalid key usage")
+			}
+		} else {
+			switch usage {
+			case EncryptCryptoKeyUsage, DecryptCryptoKeyUsage, WrapKeyCryptoKeyUsage, UnwrapKeyCryptoKeyUsage:
+			default:
+				return nil, NewError(0, SyntaxError, "invalid key usage")
+			}
+		}
+	}
+
+	// 2.
+	if a.Length != int(KeyLength128) && a.Length != int(KeyLength192) && a.Length != int(KeyLength256) {
+		return nil, NewError(0, OperationError, "invalid key length")
+	}
+
+	// 3.
+	// FIXME: verify if there are different constraints on the key format depending on the AES flavor
+	randomKey := make([]byte, a.Length/8)
+	_, err := rand.Read(randomKey)
+	if err != nil {
+		// 4.
+		return nil, NewError(0, OperationError, "could not generate random key")
+	}
+
+	// 5. 6. 7. 8. 9.
+	key := CryptoKey[[]byte]{}
+	key.Type = SecretCryptoKeyType
+	key.Algorithm = AesKeyAlgorithm{
+		KeyAlgorithm: KeyAlgorithm{
+			Name: a.Name,
+		},
+		Length: a.Length,
+	}
+
+	// 10.
+	key.Extractable = extractable
+
+	// 11.
+	key.Usages = keyUsages
+
+	// Set key handle to our random key.
+	key.handle = randomKey
+
+	// We apply the generateKey 8. step here, as we return a goja.Value
+	// instead of a CryptoKey(Pair).
+	if key.Usages == nil || len(key.Usages) == 0 {
+		return nil, NewError(0, SyntaxError, "the keyUsages argument must contain at least one valid usage for the algorithm")
+	}
+
+	// 12.
+	return rt.ToValue(key), nil
+}

--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -222,9 +222,13 @@ func NormalizeAlgorithm(algorithm interface{}, op OperationIdentifier) (interfac
 	}
 
 	// 6.
-	// FIXME: handle this case in later versions
-	err := NewError(0, ImplementationError, fmt.Sprintf("unsupported algorithm type: %s", desiredType))
-	return Algorithm{}, err
+	// FIXME: the case strings should be constants
+	switch desiredType {
+	case "AesKeyGenParams":
+		return AesKeyGenParams{}.From(initialAlg)
+	default:
+		return Algorithm{}, NewError(0, ImplementationError, fmt.Sprintf("unsupported algorithm type: %s", desiredType))
+	}
 }
 
 // As defined by the [specification]

--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -226,6 +226,8 @@ func NormalizeAlgorithm(algorithm interface{}, op OperationIdentifier) (interfac
 	switch desiredType {
 	case "AesKeyGenParams":
 		return AesKeyGenParams{}.From(initialAlg)
+	case "EcKeyGenParams":
+		return EcKeyGenParams{}.From(initialAlg)
 	default:
 		return Algorithm{}, NewError(0, ImplementationError, fmt.Sprintf("unsupported algorithm type: %s", desiredType))
 	}

--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -228,6 +228,8 @@ func NormalizeAlgorithm(algorithm interface{}, op OperationIdentifier) (interfac
 		return AesKeyGenParams{}.From(initialAlg)
 	case "EcKeyGenParams":
 		return EcKeyGenParams{}.From(initialAlg)
+	case "HmacKeyGenParams":
+		return HmacKeyGenParams{}.From(initialAlg)
 	default:
 		return Algorithm{}, NewError(0, ImplementationError, fmt.Sprintf("unsupported algorithm type: %s", desiredType))
 	}

--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -230,6 +230,8 @@ func NormalizeAlgorithm(algorithm interface{}, op OperationIdentifier) (interfac
 		return EcKeyGenParams{}.From(initialAlg)
 	case "HmacKeyGenParams":
 		return HmacKeyGenParams{}.From(initialAlg)
+	case "RsaHashedKeyGenParams":
+		return RsaHashedKeyGenParams{}.From(initialAlg)
 	default:
 		return Algorithm{}, NewError(0, ImplementationError, fmt.Sprintf("unsupported algorithm type: %s", desiredType))
 	}

--- a/webcrypto/elliptic_curve.go
+++ b/webcrypto/elliptic_curve.go
@@ -1,5 +1,213 @@
 package webcrypto
 
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+// EcKeyAlgorithm represents the Elliptic Curve key algorithm.
+type EcKeyAlgorithm struct {
+	KeyAlgorithm
+
+	NamedCurve EllipticCurveKind `json:"namedCurve"`
+}
+
+// The ECDSAParams represents the object that should be passed as the algorithm
+// parameter into `SubtleCrypto.Sign` or `SubtleCrypto.Verify“ when using the
+// ECDSA algorithm.
+//
+// As defined in the [specification](https://www.w3.org/TR/WebCryptoAPI/#EcdsaParams-dictionary)
+type ECDSAParams struct {
+	// Name should be set to AlgorithmKindEcdsa.
+	Name AlgorithmIdentifier `json:"name"`
+
+	// Hash identifies the name of the digest algorithm to use.
+	// You can use any of the following:
+	//   * [Sha256]
+	//   * [Sha384]
+	//   * [Sha512]
+	Hash AlgorithmIdentifier `json:"hash"`
+}
+
+// EcKeyGenParams  represents the object that should be passed as the algorithm
+// parameter into `SubtleCrypto.GenerateKey`, when generating any
+// elliptic-curve-based key pair: that is, when the algorithm is identified
+// as either of AlgorithmKindEcdsa or AlgorithmKindEcdh.
+//
+// As defined in the [specification](https://www.w3.org/TR/WebCryptoAPI/#EcKeyGenParams-dictionary)
+type EcKeyGenParams struct {
+	// Algorithm holds the base algorithm description.
+	// Its name should be set to either ECDSA or ECDH.
+	Algorithm
+
+	// NamedCurve holds (a String) the name of the curve to use.
+	// You can use any of the following: CurveKindP256, CurveKindP384, or CurveKindP521.
+	NamedCurve EllipticCurveKind `json:"namedCurve"`
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ From[map[string]interface{}, EcKeyGenParams] = EcKeyGenParams{}
+
+// From implements the From interface for EcKeyGenParams, and initializes the
+// EcKeyGenParams instance from a map[string]interface{}.
+func (e EcKeyGenParams) From(dict map[string]interface{}) (EcKeyGenParams, error) {
+	var params EcKeyGenParams
+	nameFound := false
+	namedCurveFound := false
+
+	for key, value := range dict {
+		if strings.EqualFold(key, "name") {
+			name, ok := value.(string)
+			if !ok {
+				return EcKeyGenParams{}, NewError(0, SyntaxError, "name property should hold a string")
+			}
+
+			name = strings.ToUpper(name)
+
+			if !IsAlgorithm(name) {
+				return EcKeyGenParams{}, NewError(0, NotSupportedError, "unsupported algorithm name")
+			}
+
+			params.Name = name
+			nameFound = true
+			continue
+		}
+
+		if strings.EqualFold(key, "namedCurve") {
+			namedCurve, ok := value.(string)
+			if !ok {
+				return EcKeyGenParams{}, NewError(0, SyntaxError, "namedCurve property should hold a string")
+			}
+
+			namedCurve = strings.ToUpper(namedCurve)
+
+			if !IsEllipticCurve(namedCurve) {
+				return EcKeyGenParams{}, NewError(0, NotSupportedError, "unsupported elliptic curve name")
+			}
+
+			params.NamedCurve = EllipticCurveKind(namedCurve)
+			namedCurveFound = true
+			continue
+		}
+	}
+
+	if !nameFound {
+		return EcKeyGenParams{}, NewError(0, SyntaxError, "missing algorithm name")
+	}
+
+	if !namedCurveFound {
+		return EcKeyGenParams{}, NewError(0, SyntaxError, "missing elliptic curve name")
+	}
+
+	return params, nil
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ KeyGenerator = &EcKeyGenParams{}
+
+// GenerateKey generates a new Elliptic Curve key pair.
+//
+//nolint:funlen
+func (e *EcKeyGenParams) GenerateKey(
+	rt *goja.Runtime,
+	extractable bool,
+	keyUsages []CryptoKeyUsage,
+) (goja.Value, error) {
+	if e.Algorithm.Name != ECDSA && e.Algorithm.Name != ECDH {
+		return nil, NewError(0, ImplementationError, "invalid algorithm name")
+	}
+
+	// There are no implementation of the Diffie-Hellman key exchange algorithm
+	// in the Go standard library, so we protect our users from ourselves (and themselves),
+	// and refuse to generate ECDH keys until it is implement in the Go stdlib.
+	//
+	// As of November 2022, a proposal has been accepted, and ECDH implementation into
+	// the golang standard library [is in progress].
+	//
+	// [is in progress]: https://github.com/golang/go/issues/52221
+	if e.Algorithm.Name == ECDH {
+		return nil, NewError(0, NotSupportedError, "ECDH key generation is not supported, yet")
+	}
+
+	// 1.
+	for _, usage := range keyUsages {
+		switch usage {
+		case SignCryptoKeyUsage, VerifyCryptoKeyUsage:
+		default:
+			return nil, NewError(0, SyntaxError, "invalid key usage")
+		}
+	}
+
+	// 2.
+	// Check if the namedCurve is supported by the implementation.
+	// Fetch the proper curve parameters.
+	// Produce a random key pair using the curve parameters.
+	if !IsEllipticCurve(string(e.NamedCurve)) {
+		// 3.
+		return nil, NewError(0, OperationError, "unsupported elliptic curve name")
+	}
+
+	var curve elliptic.Curve
+	switch e.NamedCurve {
+	case EllipticCurveKindP256:
+		curve = elliptic.P256()
+	case EllipticCurveKindP384:
+		curve = elliptic.P384()
+	case EllipticCurveKindP521:
+		curve = elliptic.P521()
+	}
+
+	privateKeyPair, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		// 3.
+		return nil, NewError(0, OperationError, "failed to generate key pair")
+	}
+
+	// 4. 5. 6.
+	algorithm := EcKeyAlgorithm{
+		KeyAlgorithm: KeyAlgorithm{
+			Name: NormalizeAlgorithmName(e.Algorithm.Name),
+		},
+		NamedCurve: e.NamedCurve,
+	}
+
+	// 7. 8. 9. 10. 11.
+	publicKey := CryptoKey[crypto.PublicKey]{}
+	publicKey.Type = PublicCryptoKeyType
+	publicKey.Algorithm = algorithm
+	publicKey.Extractable = true
+	publicKey.Usages = UsageIntersection(keyUsages, []CryptoKeyUsage{VerifyCryptoKeyUsage})
+	publicKey.handle = privateKeyPair.Public()
+
+	// 12. 13. 14. 15. 16.
+	privateKey := CryptoKey[crypto.PrivateKey]{}
+	privateKey.Type = PrivateCryptoKeyType
+	privateKey.Algorithm = algorithm
+	privateKey.Extractable = extractable
+	privateKey.Usages = UsageIntersection(keyUsages, []CryptoKeyUsage{SignCryptoKeyUsage})
+	privateKey.handle = privateKeyPair
+
+	// We apply the generateKey 8. step here, as we return a goja.Value
+	// instead of a CryptoKey(Pair).
+	if privateKey.Usages == nil || len(privateKey.Usages) == 0 {
+		return nil, NewError(0, SyntaxError, "the keyUsages argument must contain at least one valid usage for the algorithm")
+	}
+
+	// 17. 18. 19.
+	result := CryptoKeyPair[crypto.PrivateKey, crypto.PublicKey]{
+		PublicKey:  publicKey,
+		PrivateKey: privateKey,
+	}
+
+	// 20.
+	return rt.ToValue(result), nil
+}
+
 // EcKeyImportParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.ImportKey` or `SubtleCrypto.UnwrapKey`, when generating any elliptic-curve-based
 // key pair: that is, when the algorithm is identified as either of ECDSA or ECDH.

--- a/webcrypto/goja.go
+++ b/webcrypto/goja.go
@@ -69,3 +69,26 @@ const (
 	// BigUint64ArrayConstructor is the name of the BigUint64ArrayConstructor constructor
 	BigUint64ArrayConstructor = "BigUint64Array"
 )
+
+// makeHandledPromise will create a promise and return its resolve and reject methods,
+// wrapped in such a way that it will block the eventloop from exiting before they are
+// called even if the promise isn't resolved by the time the current script ends executing.
+func (sc *SubtleCrypto) makeHandledPromise() (*goja.Promise, func(interface{}), func(interface{})) {
+	runtime := sc.vu.Runtime()
+	callback := sc.vu.RegisterCallback()
+	p, resolve, reject := runtime.NewPromise()
+
+	return p, func(i interface{}) {
+			// more stuff
+			callback(func() error {
+				resolve(i)
+				return nil
+			})
+		}, func(i interface{}) {
+			// more stuff
+			callback(func() error {
+				reject(i)
+				return nil
+			})
+		}
+}

--- a/webcrypto/hmac.go
+++ b/webcrypto/hmac.go
@@ -1,0 +1,212 @@
+package webcrypto
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+// HmacKeyAlgorithm represents the [HMAC key algorithm].
+//
+// [HMAC key algorithm]: https://www.w3.org/TR/WebCryptoAPI/#HmacKeyAlgorithm-dictionary
+type HmacKeyAlgorithm struct {
+	KeyAlgorithm
+
+	// The inner hash function to use
+	Hash KeyAlgorithm `json:"hash"`
+
+	// The length (in bits) of the key.
+	Length uint32 `json:"length"`
+}
+
+// HmacKeyGenParams represents the [HMAC key generation parameters].
+//
+// [HMAC key generation parameters]: https://www.w3.org/TR/WebCryptoAPI/#hmac-keygen-params
+type HmacKeyGenParams struct {
+	Algorithm
+
+	// The inner hash function to use
+	// FIXME: we derive from the specs here by accepting only a string, and not
+	// an object as algorithm for HMAC.hash for instance
+	Hash HashAlgorithmIdentifier `json:"hash"`
+
+	// The length (in bits) of the key to generate. If unspecified, the
+	// recommended length will be used, which is the size of the associated
+	// hash function.
+	Length *uint32 `json:"length"`
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ From[map[string]interface{}, HmacKeyGenParams] = HmacKeyGenParams{}
+
+// From implements the From interface for HmacKeyGenParams, and initializes the
+// instance from a map[string]interface{}.
+//
+//nolint:ifshort
+func (h HmacKeyGenParams) From(dict map[string]interface{}) (HmacKeyGenParams, error) {
+	params := HmacKeyGenParams{}
+	nameFound := false
+	hashFound := false
+
+	for key, value := range dict {
+		if strings.EqualFold(key, "name") {
+			name, ok := value.(string)
+			if !ok {
+				return HmacKeyGenParams{}, NewError(0, SyntaxError, fmt.Sprintf("the %s property must be a string", key))
+			}
+
+			name = strings.ToUpper(name)
+
+			if !IsAlgorithm(name) {
+				err := NewError(0, NotSupportedError, fmt.Sprintf("the %s property is not a supported algorithm", key))
+				return HmacKeyGenParams{}, err
+			}
+
+			params.Name = name
+			nameFound = true
+			continue
+		}
+
+		if strings.EqualFold(key, "hash") {
+			switch t := dict[key].(type) {
+			case string:
+				t = strings.ToUpper(t)
+
+				if !IsHashAlgorithm(t) {
+					return HmacKeyGenParams{}, NewError(0, "NotSupportedError", fmt.Sprintf("Unsupported hash algorithm  %s", t))
+				}
+
+				params.Hash = t
+				hashFound = true
+			case map[string]interface{}:
+				alg, err := Algorithm{}.From(t)
+				if err != nil {
+					return HmacKeyGenParams{}, err
+				}
+
+				params.Hash = alg.Name
+				hashFound = true
+			}
+
+			continue
+		}
+
+		if strings.EqualFold(key, "length") {
+			length, ok := value.(int64)
+			if !ok {
+				return HmacKeyGenParams{}, NewError(0, SyntaxError, fmt.Sprintf("the %s property must be a number", key))
+			}
+
+			ulength := uint32(length)
+			params.Length = &ulength
+			continue
+		}
+	}
+
+	if !nameFound {
+		return HmacKeyGenParams{}, NewError(0, SyntaxError, "the name property is missing")
+	}
+
+	if !hashFound {
+		return HmacKeyGenParams{}, NewError(0, SyntaxError, "the hash property is missing")
+	}
+
+	return params, nil
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ KeyGenerator = &HmacKeyGenParams{}
+
+// GenerateKey generates a HMAC key.
+//
+// It implements the HMAC key generation operation of the Web Crypto [specification] 29.6.
+//
+// [specification]: https://www.w3.org/TR/WebCryptoAPI/#hmac
+//
+//nolint:funlen
+func (h *HmacKeyGenParams) GenerateKey(
+	rt *goja.Runtime,
+	extractable bool,
+	keyUsages []CryptoKeyUsage,
+) (goja.Value, error) {
+	if h.Algorithm.Name != "HMAC" {
+		return nil, NewError(0, ImplementationError, "the algorithm is not HMAC")
+	}
+
+	// 1.
+	for _, usage := range keyUsages {
+		switch usage {
+		case SignCryptoKeyUsage, VerifyCryptoKeyUsage:
+		default:
+			return nil, NewError(0, SyntaxError, "invalid key usage")
+		}
+	}
+
+	// 2.
+	var length uint32
+	if h.Length == nil {
+		switch h.Hash {
+		case Sha1:
+			length = 512
+		case Sha256:
+			length = 512
+		case Sha384:
+			length = 1024
+		case Sha512:
+			length = 1024
+		default:
+			return nil, NewError(0, OperationError, "unsupported hash algorithm")
+		}
+	} else {
+		length = *h.Length
+	}
+
+	// Generate a random corresponding to the
+	// hash algorithm's block size.
+	randomKey := make([]byte, length/8)
+	if _, err := rand.Read(randomKey); err != nil {
+		return nil, NewError(0, OperationError, err.Error())
+	}
+
+	// 3.
+	hashFn, err := Hasher(h.Hash)
+	if err != nil {
+		return nil, NewError(0, OperationError, err.Error())
+	}
+	hmacHash := hmac.New(hashFn, randomKey)
+
+	// 5.
+	key := CryptoKey[[]byte]{
+		Type:   SecretCryptoKeyType,
+		handle: hmacHash.Sum(nil),
+	}
+
+	// 6. 7. 8. 9. 10.
+	algorithm := HmacKeyAlgorithm{}
+	algorithm.Name = NormalizeAlgorithmName(h.Name)
+	hash := KeyAlgorithm{}
+	hash.Name = NormalizeAlgorithmName(h.Hash)
+	algorithm.Hash = hash
+	algorithm.Length = length
+
+	// 11.
+	key.Algorithm = algorithm
+
+	// 12.
+	key.Extractable = extractable
+
+	// 13.
+	key.Usages = keyUsages
+
+	// We apply the generateKey 8. step here, as we return a goja.Value
+	// instead of a CryptoKey(Pair).
+	if key.Usages == nil || len(key.Usages) == 0 {
+		return nil, NewError(0, SyntaxError, "the keyUsages argument must contain at least one valid usage for the algorithm")
+	}
+
+	// 14.
+	return rt.ToValue(key), nil
+}

--- a/webcrypto/key.go
+++ b/webcrypto/key.go
@@ -76,6 +76,10 @@ type KeyAlgorithm struct {
 	Name AlgorithmIdentifier `json:"name"`
 }
 
+type CryptoKeyAlgorithm interface {
+	AesKeyGenParams | RSAHashedKeyGenParams | EcKeyGenParams | HMACKeyGenParams
+}
+
 // CryptoKeyType represents the type of a key.
 //
 // Note that it is defined as an alias of string, instead of a dedicated type,

--- a/webcrypto/key.go
+++ b/webcrypto/key.go
@@ -77,7 +77,7 @@ type KeyAlgorithm struct {
 }
 
 type CryptoKeyAlgorithm interface {
-	AesKeyGenParams | RSAHashedKeyGenParams | EcKeyGenParams | HMACKeyGenParams
+	AesKeyGenParams | RSAHashedKeyGenParams | HMACKeyGenParams
 }
 
 // CryptoKeyType represents the type of a key.

--- a/webcrypto/key.go
+++ b/webcrypto/key.go
@@ -56,7 +56,6 @@ type CryptoKey[H KeyHandle] struct {
 
 	// handle is an internal slot, holding the underlying key data.
 	// See [specification](https://www.w3.org/TR/WebCryptoAPI/#dfnReturnLink-0).
-	//nolint:unused
 	handle H
 }
 
@@ -76,6 +75,7 @@ type KeyAlgorithm struct {
 	Name AlgorithmIdentifier `json:"name"`
 }
 
+// CryptoKeyAlgorithm represents a cryptographic key algorithm.
 type CryptoKeyAlgorithm interface {
 	AesKeyGenParams | RSAHashedKeyGenParams | HMACKeyGenParams
 }

--- a/webcrypto/params.go
+++ b/webcrypto/params.go
@@ -94,58 +94,20 @@ type AESGcmParams struct {
 	TagLength int
 }
 
+// AESKwParams represents the object that should be passed as the algorithm parameter
 type AESKwParams struct {
 	// Name should be set to AlgorithmKindAesKw.
 	Name AlgorithmIdentifier
 }
 
-// The ECDSAParams represents the object that should be passed as the algorithm
-// parameter into `SubtleCrypto.Sign` or `SubtleCrypto.Verify“ when using the
-// ECDSA algorithm.
-type ECDSAParams struct {
-	// Name should be set to AlgorithmKindEcdsa.
-	Name AlgorithmIdentifier
-
-	// Hash identifies the name of the digest algorithm to use.
-	// You can use any of the following:
-	//   * [Sha256]
-	//   * [Sha384]
-	//   * [Sha512]
-	Hash AlgorithmIdentifier
-}
-
-// ECKeyGenParams  represents the object that should be passed as the algorithm
-// parameter into `SubtleCrypto.GenerateKey`, when generating any
-// elliptic-curve-based key pair: that is, when the algorithm is identified
-// as either of AlgorithmKindEcdsa or AlgorithmKindEcdh.
-type ECKeyGenParams struct {
-	// Name should be set to AlgorithmKindEcdsa or AlgorithmKindEcdh.
-	Name AlgorithmIdentifier
-
-	// NamedCurve holds (a String) the name of the curve to use.
-	// You can use any of the following: CurveKindP256, CurveKindP384, or CurveKindP521.
-	NamedCurve EllipticCurveKind
-}
-
-// ECKeyImportParams represents the object that should be passed as the algorithm parameter
-// into `SubtleCrypto.ImportKey` or `SubtleCrypto.UnwrapKey`, when generating any elliptic-curve-based
-// key pair: that is, when the algorithm is identified as either of ECDSA or ECDH.
-type ECKeyImportParams struct {
-	// Name should be set to AlgorithmKindEcdsa or AlgorithmKindEcdh.
-	Name AlgorithmIdentifier
-
-	// NamedCurve holds (a String) the name of the elliptic curve to use.
-	NamedCurve EllipticCurveKind
-}
-
 // ECDHKeyDeriveParams represents the object that should be passed as the algorithm
 // parameter into `SubtleCrypto.DeriveKey`, when using the ECDH algorithm.
-type ECDHKeyDeriveParams[Handle []byte] struct {
+type ECDHKeyDeriveParams[A CryptoKeyAlgorithm, H KeyHandle] struct {
 	// Name should be set to AlgorithmKindEcdh.
 	Name AlgorithmIdentifier
 
 	// Public holds (a CryptoKey) the public key of the other party.
-	Public CryptoKey[Handle]
+	Public CryptoKey[H]
 }
 
 // HKDFParams represents the object that should be passed as the algorithm parameter

--- a/webcrypto/params.go
+++ b/webcrypto/params.go
@@ -94,21 +94,6 @@ type AESGcmParams struct {
 	TagLength int
 }
 
-// AESKeyGenParams represents the object that should be passed as
-// the algorithm parameter into `SubtleCrypto.generateKey`, when generating
-// an AES key: that is, when the algorithm is identified as any
-// of AES-CBC, AES-CTR, AES-GCM, or AES-KW.
-type AESKeyGenParams struct {
-	// Name should be set to `AES-CBC`, `AES-CTR`, `AES-GCM`, or `AES-KW`.
-	Name AlgorithmIdentifier
-
-	// Length holds (a Number) the length of the key, in bits.
-	Length int
-}
-
-// AESKwParams represents the object that should be passed as the algorithm parameter
-// into `SubtleCrypto.Encrypt`, `SubtleCrypto.Decrypt`, `SubtleCrypto.WrapKey`, or
-// `SubtleCrypto.UnwrapKey`, when using the AES-KW algorithm.
 type AESKwParams struct {
 	// Name should be set to AlgorithmKindAesKw.
 	Name AlgorithmIdentifier

--- a/webcrypto/rsa.go
+++ b/webcrypto/rsa.go
@@ -1,0 +1,230 @@
+package webcrypto
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+// RsaKeyAlgorithm represents the [RSA key algorithm].
+//
+// [RSA key algorithm]: https://www.w3.org/TR/WebCryptoAPI/#RsaKeyAlgorithm-dictionary
+type RsaKeyAlgorithm struct {
+	KeyAlgorithm
+
+	// ModulusLength contains the length, in bits, of the RSA modulus.
+	ModulusLength uint32 `json:"modulusLength"`
+
+	// PublicExponent contains the RSA public exponent value of the key to generate.
+	PublicExponent []byte `json:"publicExponent"`
+}
+
+// RsaHashedKeyAlgorithm represents the [RSA algorithm for hashed keys].
+//
+// [RSA algorithm for hashed keys]: https://www.w3.org/TR/WebCryptoAPI/#RsaHashedKeyAlgorithm-dictionary
+type RsaHashedKeyAlgorithm struct {
+	RsaKeyAlgorithm
+
+	// Hash contains the hash algorithm that is used with this key.
+	Hash KeyAlgorithm `json:"hash"`
+}
+
+// RsaKeyGenParams represents the [RSA key generation parameters].
+//
+// [RSA key generation parameters]: https://www.w3.org/TR/WebCryptoAPI/#RsaKeyGenParams-dictionary
+type RsaKeyGenParams struct {
+	Algorithm
+
+	// ModulusLength contains the length, in bits, of the RSA modulus.
+	ModulusLength uint32 `json:"modulusLength"`
+
+	// PublicExponent contains the RSA public exponent value of the key to generate.
+	PublicExponent []byte `json:"publicExponent"`
+}
+
+// RsaHashedKeyGenParams represents the RSA algorithm for hashed keys [key generation parameters].
+//
+// [key generation parameters]: https://www.w3.org/TR/WebCryptoAPI/#RsaHashedKeyGenParams-dictionary
+type RsaHashedKeyGenParams struct {
+	RsaKeyGenParams
+
+	// Hash contains the hash algorithm to use.
+	Hash HashAlgorithmIdentifier `json:"hash"`
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ From[map[string]interface{}, RsaHashedKeyGenParams] = RsaHashedKeyGenParams{}
+
+// From implements the From interface for RsaHashedKeyGenParams, and initializes the
+// instance from a map[string]interface{}.
+//
+//nolint:funlen,gocognit
+func (r RsaHashedKeyGenParams) From(dict map[string]interface{}) (RsaHashedKeyGenParams, error) {
+	params := RsaHashedKeyGenParams{}
+	nameFound := false
+	modulusLengthFound := false
+	publicExponentFound := false
+	hashFound := false
+
+	for key, value := range dict {
+		if strings.EqualFold(key, "name") {
+			name, ok := value.(string)
+			if !ok {
+				return RsaHashedKeyGenParams{}, NewError(0, SyntaxError, "name property should hold a string")
+			}
+
+			if !IsAlgorithm(name) {
+				return RsaHashedKeyGenParams{}, NewError(0, NotSupportedError, "unsupported algorithm name")
+			}
+
+			params.Name = name
+			nameFound = true
+			continue
+		}
+
+		if strings.EqualFold(key, "modulusLength") {
+			length, ok := value.(int64)
+			if !ok {
+				return RsaHashedKeyGenParams{}, NewError(0, SyntaxError, "modulusLength property should hold a number")
+			}
+
+			params.ModulusLength = uint32(length)
+			modulusLengthFound = true
+			continue
+		}
+
+		if strings.EqualFold(key, "publicExponent") {
+			exponent, ok := value.([]byte)
+			if !ok && exponent != nil {
+				return RsaHashedKeyGenParams{}, NewError(0, SyntaxError, "publicExponent property should hold a Uint8Array")
+			}
+
+			params.PublicExponent = exponent
+			publicExponentFound = true
+			continue
+		}
+
+		// As opposed to HmacKeyGenParams, RsaHashedKeyGenParams' hash
+		// can only be a string.
+		if strings.EqualFold(key, "hash") {
+			hash, ok := value.(string)
+			if !ok {
+				return RsaHashedKeyGenParams{}, NewError(0, SyntaxError, "hash property should hold a string")
+			}
+
+			hash = strings.ToUpper(hash)
+
+			if !IsAlgorithm(hash) && !IsHashAlgorithm(hash) {
+				return RsaHashedKeyGenParams{}, NewError(0, NotSupportedError, "unsupported hashing algorithm name")
+			}
+
+			params.Hash = hash
+			hashFound = true
+			continue
+		}
+	}
+
+	if !nameFound {
+		return RsaHashedKeyGenParams{}, NewError(0, NotSupportedError, "missing algorithm name")
+	}
+
+	if !modulusLengthFound {
+		return RsaHashedKeyGenParams{}, NewError(0, SyntaxError, "missing modulusLength property")
+	}
+
+	if !publicExponentFound {
+		return RsaHashedKeyGenParams{}, NewError(0, SyntaxError, "missing publicExponent property")
+	}
+
+	if !hashFound {
+		return RsaHashedKeyGenParams{}, NewError(0, SyntaxError, "missing hash algorithm name")
+	}
+
+	return params, nil
+}
+
+// Ensure AesKeyGenParams implements the From interface.
+var _ KeyGenerator = &RsaHashedKeyGenParams{}
+
+// GenerateKey implements the KeyGenerator interface for RsaHashedKeyGenParams, and generates
+// a new RSA key pair.
+func (r RsaHashedKeyGenParams) GenerateKey(
+	rt *goja.Runtime,
+	extractable bool,
+	keyUsages []CryptoKeyUsage,
+) (goja.Value, error) {
+	var (
+		isSSAPKCS1v15 = strings.EqualFold(r.Name, RSASsaPkcs1v15)
+		isPSS         = strings.EqualFold(r.Name, RSAPss)
+		isOAEP        = strings.EqualFold(r.Name, RSAOaep)
+	)
+
+	if !isSSAPKCS1v15 && !isPSS && !isOAEP {
+		return nil, NewError(0, ImplementationError, "unsupported algorithm name")
+	}
+
+	// 1.
+	for _, usage := range keyUsages {
+		if strings.EqualFold(r.Name, RSAOaep) {
+			switch usage {
+			case EncryptCryptoKeyUsage, DecryptCryptoKeyUsage, WrapKeyCryptoKeyUsage, UnwrapKeyCryptoKeyUsage:
+			default:
+				return nil, NewError(0, SyntaxError, "invalid key usage")
+			}
+		} else {
+			switch usage {
+			case SignCryptoKeyUsage, VerifyCryptoKeyUsage:
+			default:
+				return nil, NewError(0, SyntaxError, "invalid key usage")
+			}
+		}
+	}
+
+	// 2.
+	keyPair, err := rsa.GenerateKey(rand.Reader, int(r.ModulusLength))
+	if err != nil {
+		// 3.
+		return nil, NewError(0, OperationError, "failed to generate RSA key pair")
+	}
+
+	// 4. 5. 6. 7. 8.
+	algorithm := RsaHashedKeyAlgorithm{}
+	algorithm.Name = NormalizeAlgorithmName(r.Name)
+	algorithm.ModulusLength = r.ModulusLength
+	algorithm.PublicExponent = r.PublicExponent
+	algorithm.Hash = KeyAlgorithm{Name: r.Hash}
+
+	// 9. 10. 11. 12. 13.
+	publicKey := CryptoKey[crypto.PublicKey]{}
+	publicKey.Type = PublicCryptoKeyType
+	publicKey.Algorithm = algorithm
+	publicKey.Extractable = true
+	publicKey.Usages = UsageIntersection(keyUsages, []CryptoKeyUsage{VerifyCryptoKeyUsage})
+	publicKey.handle = keyPair.Public()
+
+	// 14. 15. 16. 17. 18.
+	privateKey := CryptoKey[crypto.PrivateKey]{}
+	privateKey.Type = PrivateCryptoKeyType
+	privateKey.Algorithm = algorithm
+	privateKey.Extractable = extractable
+	privateKey.Usages = UsageIntersection(keyUsages, []CryptoKeyUsage{SignCryptoKeyUsage})
+	privateKey.handle = keyPair
+
+	// We apply the generateKey 8. step here, as we return a goja.Value
+	// instead of a CryptoKey(Pair).
+	if privateKey.Usages == nil || len(privateKey.Usages) == 0 {
+		return nil, NewError(0, SyntaxError, "the keyUsages argument must contain at least one valid usage for the algorithm")
+	}
+
+	// 19. 20. 21.
+	result := CryptoKeyPair[crypto.PrivateKey, crypto.PublicKey]{
+		PublicKey:  publicKey,
+		PrivateKey: privateKey,
+	}
+
+	// 22.
+	return rt.ToValue(result), nil
+}

--- a/webcrypto/subtle_crypto_test.go
+++ b/webcrypto/subtle_crypto_test.go
@@ -1,0 +1,330 @@
+package webcrypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FIXME: Add failure tests.
+func TestSubtleCryptoGenerateKey(t *testing.T) {
+	t.Parallel()
+
+	// We compile the helpers script content into a goja Program
+	helpersProgram, err := CompileFile("../testdata/scripts", "helpers.js")
+	require.NoError(t, err)
+
+	// We compile the assert script content into a goja Program
+	// We compile the helpers script content into a goja Program
+	assertProgram, err := CompileFile("../testdata/scripts", "assert.js")
+	require.NoError(t, err)
+
+	t.Run("successes", func(t *testing.T) {
+		t.Parallel()
+		ts := newTestSetup(t)
+
+		gotScriptErr := ts.ev.Start(func() error {
+			// FIXME: move compiling to the test setup
+			// We execute the helpers script in the runtime which effectively
+			// loads the helper functions into the runtime
+			_, err = ts.rt.RunProgram(helpersProgram)
+			require.NoError(t, err)
+
+			// We execute the helpers script in the runtime which effectively
+			// loads the helper functions into the runtime
+			_, err = ts.rt.RunProgram(assertProgram)
+			require.NoError(t, err)
+
+			// Run the test script. Note that
+			_, err = ts.rt.RunString(`
+				var subtle = crypto.subtle;
+
+				var testVectors = [ // Parameters that should work for generateKey
+					{name: "AES-CTR",  resultType: "CryptoKey", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "AES-CBC",  resultType: "CryptoKey", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "AES-GCM",  resultType: "CryptoKey", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "AES-KW",   resultType: "CryptoKey", usages: ["wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "HMAC",     resultType: "CryptoKey", usages: ["sign", "verify"], mandatoryUsages: []},
+					{name: "RSASSA-PKCS1-v1_5", resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+					{name: "RSA-PSS",  resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+					{name: "RSA-OAEP", resultType: "CryptoKeyPair", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: ["decrypt", "unwrapKey"]},
+					{name: "ECDSA",    resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+				];
+
+				testVectors = testVectors.filter((vector) => {
+					allNameVariants(vector.name).forEach((name) => {
+						allAlgorithmSpecifiersFor(name).forEach((algorithm) => {
+							allValidUsages(vector.usages, false, vector.mandatoryUsages).forEach((usages) => {
+								[false, true].forEach((extractable) => {
+
+									subtle.generateKey(algorithm, extractable, usages).then(
+										(result) => {
+											if (vector.resultType === "CryptoKeyPair") {
+												assert_goodCryptoKey(result.privateKey, algorithm, extractable, usages, "private");
+												assert_goodCryptoKey(result.publicKey, algorithm, extractable, usages, "public");
+											} else {
+												assert_goodCryptoKey(result, algorithm, extractable, usages, "secret");
+											}
+										},
+										(err) => {
+											throw "Threw an unexpected error: " + err
+										}
+									)
+
+								})
+							})
+						})
+					})
+				})
+
+				function assert_goodCryptoKey(key, algorithm, extractable, usages, kind) {
+					var correctUsages = [];
+
+					// Defined in helpers.js
+					var registeredAlgorithmName;
+					registeredAlgorithmNames.forEach(function(name) {
+						if (name.toUpperCase() === algorithm.name.toUpperCase()) {
+							registeredAlgorithmName = name;
+						}
+					});
+
+					assert_equals(key.type, kind, "is a " + kind + " key");
+					if (key.type === "public") {
+						extractable = true;  // public keys are always extractable
+					}
+
+					assert_equals(key.extractable, extractable, "extractability is correct");
+					assert_equals(key.algorithm.name, registeredAlgorithmName, "algorithm name is correct");
+
+					if (key.algorithm.name.toUpperCase() === "HMAC" && algorithm.length === undefined) {
+						switch (key.algorithm.hash.name.toUpperCase()) {
+						case "SHA-1":
+						case "SHA-256":
+							assert_equals(key.algorithm.length, 512, "correct length");
+							break;
+						case "SHA-384":
+						case "SHA-512":
+							assert_equals(key.algorithm.length, 1024, "correct length");
+							break;
+						}
+					} else {
+						assert_equals(key.algorithm.length, algorithm.length, "correct length");
+					}
+
+					// if (registeredAlgorithmName === "HMAC" ||
+					// 	registeredAlgorithmName === "RSASSA-PKCS1-v1_5" ||
+					// 	registeredAlgorithmName === "RSA-PSS") {
+					if ([ "HMAC", "RSASSA-PKCS1-v1_5", "RSA-PSS" ].includes(registeredAlgorithmName)) {
+						assert_equals(key.algorithm.hash.name.toUpperCase(), algorithm.hash.toUpperCase(), "correct hash function");
+					}
+
+					// usages is expected to be provided for a key pair, but we are checking
+					// only a single key. The publicKey and privateKey portions of a key pair
+					// recognize only some of the usages appropriate for a key pair.
+					if (key.type === "public") {
+						["encrypt", "verify", "wrapKey"].forEach(function(usage) {
+							if (usages.includes(usage)) {
+								correctUsages.push(usage);
+							}
+						});
+					} else if (key.type === "private") {
+						["decrypt", "sign", "unwrapKey", "deriveKey", "deriveBits"].forEach(function(usage) {
+							if (usages.includes(usage)) {
+								correctUsages.push(usage);
+							}
+						});
+					} else {
+						correctUsages = usages;
+					}
+
+					assert_equals((typeof key.usages), "object", key.type + " key usages is an object");
+					assert_not_equals(key.usages, null, key.type + " key usages is not null");
+
+					var usageCount = 0;
+					key.usages.forEach(function(usage) {
+						usageCount += 1
+						assert_in_array(usage, correctUsages, "has " + usage + " usage");
+					})
+
+					assert_equals(key.usages.length, usageCount, "usages property is correct");
+				}
+			`)
+
+			return err
+		})
+
+		assert.NoError(t, gotScriptErr)
+	})
+
+	t.Run("failures", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestSetup(t)
+
+		gotScriptErr := ts.ev.Start(func() error {
+			// FIXME: move compiling to the test setup
+			// We execute the helpers script in the runtime which effectively
+			// loads the helper functions into the runtime
+			_, err = ts.rt.RunProgram(helpersProgram)
+			require.NoError(t, err)
+
+			// We execute the helpers script in the runtime which effectively
+			// loads the helper functions into the runtime
+			_, err = ts.rt.RunProgram(assertProgram)
+			require.NoError(t, err)
+
+			// Run the test script. Note that
+			_, err = ts.rt.RunString(`
+				var subtle = crypto.subtle;
+
+				var allTestVectors = [ // Parameters that should work for generateKey
+					{name: "AES-CTR",  resultType: "CryptoKey", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "AES-CBC",  resultType: "CryptoKey", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "AES-GCM",  resultType: "CryptoKey", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "AES-KW",   resultType: "CryptoKey", usages: ["wrapKey", "unwrapKey"], mandatoryUsages: []},
+					{name: "HMAC",     resultType: "CryptoKey", usages: ["sign", "verify"], mandatoryUsages: []},
+					{name: "RSASSA-PKCS1-v1_5", resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+					{name: "RSA-PSS",  resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+					{name: "RSA-OAEP", resultType: "CryptoKeyPair", usages: ["encrypt", "decrypt", "wrapKey", "unwrapKey"], mandatoryUsages: ["decrypt", "unwrapKey"]},
+					{name: "ECDSA",    resultType: "CryptoKeyPair", usages: ["sign", "verify"], mandatoryUsages: ["sign"]},
+
+					// {name: "ECDH",     resultType: "CryptoKeyPair", usages: ["deriveKey", "deriveBits"], mandatoryUsages: ["deriveKey", "deriveBits"]},
+				];
+
+				algorithmNames = allTestVectors.map(function(v) { return v.name; });
+
+				var testVectors = [];
+				if (algorithmNames && !Array.isArray(algorithmNames)) {
+					algorithmNames = [algorithmNames];
+				};
+				allTestVectors.forEach(function(vector) {
+					if (!algorithmNames || algorithmNames.includes(vector.name)) {
+						testVectors.push(vector);
+					}
+				});
+
+				function testError(algorithm, extractable, usages, expectedError, testTag) {
+					subtle.generateKey(algorithm, extractable, usages)
+						.then(
+							(result) => { assert_unreached("operation succeeded, but should not have") },
+							(err) => {
+								assert_equals(err.name, expectedError, testTag + " not supported");
+							}
+						)
+				}
+
+				// Given an algorithm name, create several invalid parameters.
+				function badAlgorithmPropertySpecifiersFor(algorithmName) {
+					var results = [];
+			
+					if (algorithmName.toUpperCase().substring(0, 3) === "AES") {
+						// Specifier properties are name and length
+						[64, 127, 129, 255, 257, 512].forEach(function(length) {
+							results.push({name: algorithmName, length: length});
+						});
+					} else if (algorithmName.toUpperCase().substring(0, 3) === "RSA") {
+						[new Uint8Array([1]), new Uint8Array([1,0,0])].forEach(function(publicExponent) {
+							results.push({name: algorithmName, hash: "SHA-256", modulusLength: 1024, publicExponent: publicExponent});
+						});
+					} else if (algorithmName.toUpperCase().substring(0, 2) === "EC") {
+						["P-512", "Curve25519"].forEach(function(curveName) {
+							results.push({name: algorithmName, namedCurve: curveName});
+						});
+					}
+			
+					return results;
+				}
+
+				// Algorithm normalization should fail with "Not supported"
+				var badAlgorithmNames = [
+					"AES",
+					{name: "AES"},
+					{name: "AES", length: 128},
+					{name: "AES-CMAC", length: 128},
+					{name: "AES-CFB", length: 128},
+					{name: "HMAC", hash: "MD5"},
+					{name: "RSA", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1,0,1])},
+					{name: "RSA-PSS", hash: "SHA", modulusLength: 2048, publicExponent: new Uint8Array([1,0,1])},
+					{name: "EC", namedCurve: "P521"}
+				];
+			
+				// Algorithm normalization failures should be found first
+				// - all other parameters can be good or bad, should fail
+				//   due to NotSupportedError.
+				badAlgorithmNames.forEach(function(algorithm) {
+					allValidUsages(["decrypt", "sign", "deriveBits"], true, []) // Small search space, shouldn't matter because should fail before used
+						.forEach(function(usages) {
+							[false, true, "RED", 7].forEach(function(extractable){
+									
+								testError(algorithm, extractable, usages, "NotSupportedError", "Bad algorithm");
+							
+							});
+						});
+				});
+
+				// Algorithms normalize okay, but usages bad (though not empty).
+				// It shouldn't matter what other extractable is. Should fail
+				// due to SyntaxError
+				testVectors.forEach(function(vector) {
+					var name = vector.name;
+			
+					allAlgorithmSpecifiersFor(name).forEach(function(algorithm) {
+						invalidUsages(vector.usages, vector.mandatoryUsages).forEach(function(usages) {
+							[true].forEach(function(extractable) {
+
+								testError(algorithm, extractable, usages, "SyntaxError", "Bad usages");
+							
+							});
+						});
+					});
+				});
+
+				// TODO: those tests are not reliable, and they fail on scenarios that
+				// are not described by the specs.
+
+				// // Other algorithm properties should be checked next, so try good
+				// // algorithm names and usages, but bad algorithm properties next.
+				// // - Special case: normally bad usage [] isn't checked until after properties,
+				// //   so it's included in this test case. It should NOT cause an error.
+				// testVectors.forEach(function(vector) {
+				// 	var name = vector.name;
+				// 	badAlgorithmPropertySpecifiersFor(name).forEach(function(algorithm) {
+				// 		allValidUsages(vector.usages, true, vector.mandatoryUsages)
+				// 		.forEach(function(usages) {
+				// 			[false, true].forEach(function(extractable) {
+
+				// 				if (name.substring(0,2) === "EC") {
+				// 					testError(algorithm, extractable, usages, "NotSupportedError", "Bad algorithm property");
+				// 				} else if (name === "RSA-OAEP") {
+				// 					testError(algorithm, extractable, usages, "SyntaxError", "Bad algorithm property");
+				// 				} else {
+				// 					testError(algorithm, extractable, usages, "OperationError", "Bad algorithm property");
+				// 				}
+
+				// 			});
+				// 		});
+				// 	});
+				// });
+
+
+
+				// The last thing that should be checked is an empty usages (for secret keys).
+				testVectors.forEach(function(vector) {
+					var name = vector.name;
+			
+					allAlgorithmSpecifiersFor(name).forEach(function(algorithm) {
+						var usages = [];
+						[false, true].forEach(function(extractable) {
+							testError(algorithm, extractable, usages, "SyntaxError", "Empty usages");
+						});
+					});
+				});
+			`)
+
+			return err
+		})
+
+		assert.NoError(t, gotScriptErr)
+	})
+}

--- a/webcrypto/test_setup.go
+++ b/webcrypto/test_setup.go
@@ -21,8 +21,6 @@ import (
 // testSetup is a helper struct holding components
 // necessary to test the redis client, in the context
 // of the execution of a k6 script.
-//
-//nolint:unused
 type testSetup struct {
 	rt      *goja.Runtime
 	state   *lib.State
@@ -34,8 +32,6 @@ type testSetup struct {
 // It prepares a test setup with a mocked redis server and a goja runtime,
 // and event loop, ready to execute scripts as if being executed in the
 // main context of k6.
-//
-//nolint:deadcode,unused
 func newTestSetup(t testing.TB) testSetup {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 


### PR DESCRIPTION
This PR addresses #13 and implements the `subtle.generateKey` operation.

It implements the function according to the [W3C specification](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-generateKey), and offers [the following API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey).

The PR contains extensive usage examples offered by the functionalities of this PR, but here's a quick, illustrative example, of an ECDSA key pair generation:
```javascript
import { crypto } from "k6/x/webcrypto";

export default function () {
  crypto.subtle
    .generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
      "sign",
      "verify",
    ])
    .then((key) => {
      console.log(JSON.stringify(key));
    });
}
```

I'm sure there are many potential improvements possible left for this, and I'm looking forward to hearing from you 🙇🏻 

@mostafa, I added you as an optional reviewer; if you have time, could you please take a quick look to ensure I haven't done something wrong on the key generation part? The code for those live in the `aes.go`, `rsa.go`, `elliptic_curve.go` and `hmac.go` files (`GenerateKey` functions).
