### PR TITLE
[2/3] Implement the `exportKey` and `importKey` operations with support for HMAC algorithm

### DIFF
--- a/examples/import_export/import-export-hmac-key.js
+++ b/examples/import_export/import-export-hmac-key.js
@@ -1,0 +1,31 @@
+import { crypto } from "k6/x/webcrypto";
+
+ export default async function () {
+    try {
+        const generatedKey = await crypto.subtle.generateKey(
+            {
+                name: "HMAC",
+                hash: { name: "SHA-256" },
+            },
+            true,
+            [
+                "sign",
+                "verify",
+            ]
+        );
+
+        const exportedKey = await crypto.subtle.exportKey("raw", generatedKey);
+
+        const importedKey = await crypto.subtle.importKey(
+            "raw",
+            exportedKey,
+            { name: "HMAC", hash: { name: "SHA-256" } },
+            true, ["sign", "verify"]
+        );
+
+        console.log(JSON.stringify(importedKey))
+    } catch (err) {
+        console.log(JSON.stringify(err));
+    }
+
+}

--- a/webcrypto/aes.go
+++ b/webcrypto/aes.go
@@ -141,7 +141,7 @@ func exportAESKey(key *CryptoKey, format KeyFormat) ([]byte, error) {
 	}
 }
 
-// AesImportParams is an internal placeholder struct for AES import parameters.
+// aesImportParams is an internal placeholder struct for AES import parameters.
 // Although not described by the specification, we define it to be able to implement
 // our internal KeyImporter interface.
 type aesImportParams struct {

--- a/webcrypto/aes.go
+++ b/webcrypto/aes.go
@@ -141,13 +141,26 @@ func exportAESKey(key *CryptoKey, format KeyFormat) ([]byte, error) {
 	}
 }
 
-// importAESKey imports an AES key from its raw representation, and returns a CryptoKey.
+// AesImportParams is an internal placeholder struct for AES import parameters.
+// Although not described by the specification, we define it to be able to implement
+// our internal KeyImporter interface.
+type aesImportParams struct {
+	Algorithm
+}
+
+func newAesImportParams(normalized Algorithm) *aesImportParams {
+	return &aesImportParams{
+		Algorithm: normalized,
+	}
+}
+
+// ImportKey imports an AES key from its raw representation.
+// It implements the KeyImporter interface.
 //
-// TODO @oleiade: support JWK format.
-func importAESKey(
+// TODO @oleiade: support JWK format #37
+func (aip *aesImportParams) ImportKey(
 	format KeyFormat,
-	algorithm Algorithm,
-	data []byte,
+	keyData []byte,
 	keyUsages []CryptoKeyUsage,
 ) (*CryptoKey, error) {
 	for _, usage := range keyUsages {
@@ -162,9 +175,9 @@ func importAESKey(
 	switch format {
 	case RawKeyFormat:
 		var (
-			has128Bits = len(data) == 16
-			has192Bits = len(data) == 24
-			has256Bits = len(data) == 32
+			has128Bits = len(keyData) == 16
+			has192Bits = len(keyData) == 24
+			has256Bits = len(keyData) == 32
 		)
 
 		if !has128Bits && !has192Bits && !has256Bits {
@@ -176,15 +189,18 @@ func importAESKey(
 
 	key := &CryptoKey{
 		Algorithm: AesKeyAlgorithm{
-			Algorithm: algorithm,
-			Length:    int64(len(data) * 8),
+			Algorithm: aip.Algorithm,
+			Length:    int64(len(keyData) * 8),
 		},
 		Type:   SecretCryptoKeyType,
-		handle: data,
+		handle: keyData,
 	}
 
 	return key, nil
 }
+
+// Ensure that aesImportParams implements the KeyImporter interface.
+var _ KeyImporter = &aesImportParams{}
 
 // AesCbcParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.Encrypt`, `SubtleCrypto.Decrypt`, `SubtleCrypto.WrapKey`, or

--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -170,7 +170,7 @@ func isRegisteredAlgorithm(algorithmName string, forOperation string) bool {
 		// FIXME: the presence of the hash algorithm here is for HMAC support and should be handled separately
 		return isAesAlgorithm(algorithmName) || isHashAlgorithm(algorithmName) || algorithmName == HMAC
 	case OperationIdentifierExportKey, OperationIdentifierImportKey:
-		return isAesAlgorithm(algorithmName)
+		return isAesAlgorithm(algorithmName) || algorithmName == HMAC
 	case OperationIdentifierEncrypt, OperationIdentifierDecrypt:
 		return isAesAlgorithm(algorithmName)
 	default:

--- a/webcrypto/hmac.go
+++ b/webcrypto/hmac.go
@@ -185,3 +185,135 @@ func exportHmacKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
 		return nil, NewError(0, NotSupportedError, "unsupported key format "+format)
 	}
 }
+
+// HmacImportParams represents the object that should be passed as the algorithm parameter
+// into `SubtleCrypto.GenerateKey`, when generating an HMAC key.
+type HmacImportParams struct {
+	Algorithm
+
+	// Hash represents the name of the digest function to use. You can
+	// use any of the following: [Sha256], [Sha384],
+	// or [Sha512].
+	Hash Algorithm `json:"hash"`
+
+	// Length holds (a Number) the length of the key, in bits.
+	// If this is omitted, the length of the key is equal to the block size
+	// of the hash function you have chosen.
+	// Unless you have a good reason to use a different length, omit
+	// use the default.
+	Length null.Int `json:"length"`
+}
+
+// newHmacImportParams creates a new HmacImportParams object from the given
+// algorithm and params objects.
+func newHmacImportParams(rt *goja.Runtime, normalized Algorithm, params goja.Value) (*HmacImportParams, error) {
+	// The specification doesn't explicitly tell us what to do if the
+	// hash field is not present, but we assume it's a mandatory field
+	// and throw an error if it's not present.
+	hashValue, err := traverseObject(rt, params, "hash")
+	if err != nil {
+		return nil, NewError(0, SyntaxError, "could not get hash from algorithm parameter")
+	}
+
+	// Although the specification doesn't explicitly ask us to do so, we
+	// normalize the hash algorithm here, as it shares the same definition
+	// as the AlgorithmIdentifier type, and we'll need it later on.
+	//
+	// Note @oleiade: The specification seems to assume that the normalization
+	// algorithm will normalize the existing Algorithm fields, and leave
+	// the rest untouched. As we are in the context of a statically typed
+	// language, we can't do that, so we need to normalize the hash
+	// algorithm here.
+	normalizedHash, err := normalizeAlgorithm(rt, hashValue, OperationIdentifierGenerateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// As the length attribute is optional and as the key generation process
+	// differentiates unset from zero-values, we need to handle the case
+	// where the length attribute is not present in the params object.
+	var length null.Int
+	algorithmLengthValue, err := traverseObject(rt, params, "length")
+	if err == nil {
+		length = null.IntFrom(algorithmLengthValue.ToInteger())
+	}
+
+	return &HmacImportParams{
+		Algorithm: normalized,
+		Hash:      normalizedHash,
+		Length:    length,
+	}, nil
+}
+
+// ImportKey imports a key from raw key data. It implements the KeyImporter interface.
+func (hip *HmacImportParams) ImportKey(
+	format KeyFormat,
+	keyData []byte,
+	keyUsages []CryptoKeyUsage,
+) (*CryptoKey, error) {
+	// 2.
+	for _, usage := range keyUsages {
+		switch usage {
+		case SignCryptoKeyUsage, VerifyCryptoKeyUsage:
+			continue
+		default:
+			return nil, NewError(0, SyntaxError, "invalid key usage: "+usage)
+		}
+	}
+
+	// 3.
+	var hash KeyAlgorithm
+
+	// 4.
+	switch format {
+	case RawKeyFormat:
+		hash = KeyAlgorithm{Algorithm{Name: hip.Hash.Name}}
+	default:
+		return nil, NewError(0, NotSupportedError, "unsupported key format "+format)
+	}
+
+	// 5. 6.
+	length := int64(len(keyData) * 8)
+	if length == 0 {
+		return nil, NewError(0, DataError, "key length cannot be 0")
+	}
+
+	// 7.
+	if hip.Length.Valid {
+		if hip.Length.Int64 > length {
+			return nil, NewError(0, DataError, "key length cannot be greater than the length of the imported data")
+		}
+
+		if hip.Length.Int64 < length {
+			return nil, NewError(0, DataError, "key length cannot be less than the length of the imported data")
+		}
+
+		length = hip.Length.Int64
+	}
+
+	// 8.
+	key := CryptoKey{
+		Type:   SecretCryptoKeyType,
+		handle: keyData[:length/8],
+	}
+
+	// 9.
+	algorithm := HmacKeyAlgorithm{}
+
+	// 10.
+	algorithm.Name = HMAC
+
+	// 11.
+	algorithm.Length = length
+
+	// 12.
+	algorithm.Hash = hash
+
+	// 13.
+	key.Algorithm = algorithm
+
+	return &key, nil
+}
+
+// Ensure that HmacImportParams implements the KeyImporter interface.
+var _ KeyImporter = &HmacImportParams{}

--- a/webcrypto/hmac.go
+++ b/webcrypto/hmac.go
@@ -163,3 +163,25 @@ type HmacKeyAlgorithm struct {
 	// Length represents he length (in bits) of the key.
 	Length int64 `json:"length"`
 }
+
+func exportHmacKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
+	// 1.
+	if ck.handle == nil {
+		return nil, NewError(0, OperationError, "key data is not accesible")
+	}
+
+	// 2.
+	bits, ok := ck.handle.([]byte)
+	if !ok {
+		return nil, NewError(0, OperationError, "key underlying data is not of the correct type")
+	}
+
+	// 4.
+	switch format {
+	case RawKeyFormat:
+		return bits, nil
+	default:
+		// FIXME: note that we do not support JWK format, yet #37.
+		return nil, NewError(0, NotSupportedError, "unsupported key format "+format)
+	}
+}

--- a/webcrypto/key.go
+++ b/webcrypto/key.go
@@ -130,6 +130,30 @@ func newKeyGenerator(rt *goja.Runtime, normalized Algorithm, params goja.Value) 
 	return kg, nil
 }
 
+// KeyImporter is the interface implemented by the parameters used to import
+// cryptographic keys.
+type KeyImporter interface {
+	ImportKey(format KeyFormat, keyData []byte, keyUsages []CryptoKeyUsage) (*CryptoKey, error)
+}
+
+func newKeyImporter(rt *goja.Runtime, normalized Algorithm, params goja.Value) (KeyImporter, error) {
+	var ki KeyImporter
+	var err error
+
+	switch normalized.Name {
+	case AESCbc, AESCtr, AESGcm, AESKw:
+		ki = newAesImportParams(normalized)
+	case HMAC:
+		ki, err = newHmacImportParams(rt, normalized, params)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ki, nil
+}
+
 // UsageIntersection returns the intersection of two slices of CryptoKeyUsage.
 //
 // It implements the algorithm described in the [specification] to

--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -610,6 +610,12 @@ func (sc *SubtleCrypto) ExportKey(format KeyFormat, key goja.Value) *goja.Promis
 				reject(err)
 				return
 			}
+		case HMAC:
+			result, err = exportHmacKey(ck, format)
+			if err != nil {
+				reject(err)
+				return
+			}
 		default:
 			reject(NewError(0, NotSupportedError, "unsupported algorithm "+keyAlgorithmName))
 			return

--- a/webcrypto/tests/import_export/symmetric.js
+++ b/webcrypto/tests/import_export/symmetric.js
@@ -28,6 +28,11 @@ var testVectors = [
     {name: "AES-CTR",               legalUsages: ["encrypt", "decrypt"],      extractable: [true, false], formats: ["raw"]},
     {name: "AES-CBC",               legalUsages: ["encrypt", "decrypt"],      extractable: [true, false], formats: ["raw"]},
     {name: "AES-GCM",               legalUsages: ["encrypt", "decrypt"],      extractable: [true, false], formats: ["raw"]},
+    {name: "HMAC", hash: "SHA-1",   legalUsages: ["sign", "verify"],          extractable: [false],       formats: ["raw"]},
+    {name: "HMAC", hash: "SHA-256", legalUsages: ["sign", "verify"],          extractable: [false],       formats: ["raw"]},
+    {name: "HMAC", hash: "SHA-384", legalUsages: ["sign", "verify"],          extractable: [false],       formats: ["raw"]},
+    {name: "HMAC", hash: "SHA-512", legalUsages: ["sign", "verify"],          extractable: [false],       formats: ["raw"]},
+
 
     // FIXME: uncomment when other symmetric algorithms, and jwk formats, are supported
     // Plus, replace the above entries with their commented-out versions.
@@ -93,11 +98,10 @@ function testFormat(format, algorithm, keyData, keySize, usages, extractable) {
                 assert_true(equalJwk(keyData, result), "Round trip works");
             }
         }, function(err) {
-            assert_unreached("Threw an unexpected error 1: " + err.toString());
+            assert_unreached("Threw an unexpected error: " + err.toString());
         });
     }, function(err) {
-        throw format + " - " + JSON.stringify(algorithm) + " - " + keyData.length + " - " + keySize + " - " + usages + " - " + extractable + " - " + err.toString();
-        assert_unreached("Threw an unexpected error 2: " + err.toString());
+        assert_unreached("Threw an unexpected error: " + err.toString());
     });
 }
 


### PR DESCRIPTION
## What is this?

This Pull Request adds support for the HMAC algorithm to the [`subtle.crypto.importKey`](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-importKey) and [`subtle.crypto.exportKey`](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-exportKey) operations. It is the second PR of a chain of three PRs converging towards introducing the `sign` and `verify` APIs to the extension. 

Our plan moving forward is to go breadth first, and implement as much of the WebCrypto API's surface, and only later to add support for more algorithms. As a result this PR comes in with the intention to support the ability to implement the [`sign`](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-sign) and [`verify`](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-verify) operations to the module.

Just like with `encrypt` and `decrypt`, the sign and verify operations test suite rely on the ability to import and export a key of a support algorithm. As a result to support sign and verify with a scope reduced to the HMAC algorithm, we need to implement `importKey` and `exportKey` first.

## Review

Note that like in the `generateKey` PR we introduce a new interface for key import: `KeyImporter`. Although we could have extended this principle to key export, we decided to delay that until we support key pairs, as we lack visibility to decide whether or not this will remain a good abstraction in the future.

This PR is based on the [HMAC support for the `generateKey`](https://github.com/grafana/xk6-webcrypto/pull/35) PR, and will act as the base for a third PR to come which will introduce the `sign` and `verify` methods to the extension.