### PR TITLE
Remove the Error `code` field

### DIFF
--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -130,19 +130,19 @@ func normalizeAlgorithm(rt *goja.Runtime, v goja.Value, op AlgorithmIdentifier) 
 	if v.ExportType().Kind() == reflect.String {
 		algorithmString, ok := v.Export().(string)
 		if !ok {
-			return Algorithm{}, NewError(0, ImplementationError, "algorithm cannot be interpreted as a string")
+			return Algorithm{}, NewError(ImplementationError, "algorithm cannot be interpreted as a string")
 		}
 
 		algorithmObject := rt.NewObject()
 		if err := algorithmObject.Set("name", algorithmString); err != nil {
-			return Algorithm{}, NewError(0, ImplementationError, "unable to transform algorithm string into an object")
+			return Algorithm{}, NewError(ImplementationError, "unable to transform algorithm string into an object")
 		}
 
 		return normalizeAlgorithm(rt, algorithmObject, op)
 	}
 
 	if err := rt.ExportTo(v, &algorithm); err != nil {
-		return Algorithm{}, NewError(0, SyntaxError, "algorithm cannot be interpreted as a string or an object")
+		return Algorithm{}, NewError(SyntaxError, "algorithm cannot be interpreted as a string or an object")
 	}
 
 	// Algorithm identifers are always upper cased.
@@ -151,7 +151,7 @@ func normalizeAlgorithm(rt *goja.Runtime, v goja.Value, op AlgorithmIdentifier) 
 	algorithm.Name = strings.ToUpper(algorithm.Name)
 
 	if !isRegisteredAlgorithm(algorithm.Name, op) {
-		return Algorithm{}, NewError(0, NotSupportedError, "unsupported algorithm: "+algorithm.Name)
+		return Algorithm{}, NewError(NotSupportedError, "unsupported algorithm: "+algorithm.Name)
 	}
 
 	return algorithm, nil

--- a/webcrypto/crypto.go
+++ b/webcrypto/crypto.go
@@ -48,7 +48,7 @@ func (c *Crypto) GetRandomValues(typedArray goja.Value) goja.Value {
 
 	// 1.
 	if !IsInstanceOf(c.vu.Runtime(), typedArray, acceptedTypes...) {
-		common.Throw(c.vu.Runtime(), NewError(0, TypeMismatchError, "typedArray parameter isn't a TypedArray instance"))
+		common.Throw(c.vu.Runtime(), NewError(TypeMismatchError, "typedArray parameter isn't a TypedArray instance"))
 	}
 
 	// 2.
@@ -58,16 +58,13 @@ func (c *Crypto) GetRandomValues(typedArray goja.Value) goja.Value {
 	obj := typedArray.ToObject(c.vu.Runtime())
 	objLength, ok := obj.Get("length").ToNumber().Export().(int64)
 	if !ok {
-		common.Throw(c.vu.Runtime(), NewError(0, TypeMismatchError, "typedArray parameter isn't a TypedArray instance"))
+		common.Throw(c.vu.Runtime(), NewError(TypeMismatchError, "typedArray parameter isn't a TypedArray instance"))
 	}
 
 	if objLength > maxRandomValuesLength {
-		// TODO: ideally we would prefer this to be an error that can be
-		// matched upon using something along the lines of `err isinstanceof QuotaExceededError`.
 		common.Throw(
 			c.vu.Runtime(),
 			NewError(
-				0,
 				QuotaExceededError,
 				fmt.Sprintf("typedArray parameter is too big; maximum length is %d", maxRandomValuesLength),
 			),

--- a/webcrypto/encryption.go
+++ b/webcrypto/encryption.go
@@ -47,12 +47,12 @@ func newEncryptDecrypter(
 		ed = new(AesGcmParams)
 		paramsObjectName = "AesGcmParams"
 	default:
-		return nil, NewError(0, NotSupportedError, "unsupported algorithm")
+		return nil, NewError(NotSupportedError, "unsupported algorithm")
 	}
 
 	if err = rt.ExportTo(params, ed); err != nil {
 		errMsg := fmt.Sprintf("invalid algorithm parameters, unable to interpret as %sParams object", paramsObjectName)
-		return nil, NewError(0, SyntaxError, errMsg)
+		return nil, NewError(SyntaxError, errMsg)
 	}
 
 	return ed, nil

--- a/webcrypto/errors.go
+++ b/webcrypto/errors.go
@@ -44,9 +44,6 @@ const (
 // Error represents a custom error emitted by the
 // Web Crypto API.
 type Error struct {
-	// Code is one of the legacy error code constants, or 0 if none match.
-	Code int `json:"code"`
-
 	// Name contains one of the strings associated with an error name.
 	Name string `json:"name"`
 
@@ -60,9 +57,8 @@ func (e *Error) Error() string {
 }
 
 // NewError returns a new WebCryptoError with the given name and message.
-func NewError(code int, name, message string) *Error {
+func NewError(name, message string) *Error {
 	return &Error{
-		Code:    code,
 		Name:    name,
 		Message: message,
 	}

--- a/webcrypto/goja.go
+++ b/webcrypto/goja.go
@@ -11,7 +11,7 @@ import (
 // and returns a copy of the underlying byte slice.
 func exportArrayBuffer(rt *goja.Runtime, v goja.Value) ([]byte, error) {
 	if isNullish(v) {
-		return nil, NewError(0, TypeError, "data is null or undefined")
+		return nil, NewError(TypeError, "data is null or undefined")
 	}
 
 	asObject := v.ToObject(rt)
@@ -22,12 +22,12 @@ func exportArrayBuffer(rt *goja.Runtime, v goja.Value) ([]byte, error) {
 	if IsTypedArray(rt, v) {
 		ab, ok = asObject.Get("buffer").Export().(goja.ArrayBuffer)
 		if !ok {
-			return nil, NewError(0, TypeError, "TypedArray.buffer is not an ArrayBuffer")
+			return nil, NewError(TypeError, "TypedArray.buffer is not an ArrayBuffer")
 		}
 	} else {
 		ab, ok = asObject.Export().(goja.ArrayBuffer)
 		if !ok {
-			return nil, NewError(0, OperationError, "data is neither an ArrayBuffer, nor a TypedArray nor DataView")
+			return nil, NewError(OperationError, "data is neither an ArrayBuffer, nor a TypedArray nor DataView")
 		}
 	}
 
@@ -46,19 +46,18 @@ func exportArrayBuffer(rt *goja.Runtime, v goja.Value) ([]byte, error) {
 // at the end of the traversal. It assumes that all the traversed fields are Objects.
 func traverseObject(rt *goja.Runtime, src goja.Value, fields ...string) (goja.Value, error) {
 	if isNullish(src) {
-		return nil, NewError(0, TypeError, "Object is null or undefined")
+		return nil, NewError(TypeError, "Object is null or undefined")
 	}
 
 	obj := src.ToObject(rt)
 	if isNullish(obj) {
-		return nil, NewError(0, TypeError, "Object is null or undefined")
+		return nil, NewError(TypeError, "Object is null or undefined")
 	}
 
 	for idx, field := range fields {
 		src = obj.Get(field)
 		if isNullish(src) {
 			return nil, NewError(
-				0,
 				TypeError,
 				fmt.Sprintf("field %s is null or undefined", strings.Join(fields[:idx+1], ".")),
 			)
@@ -67,7 +66,6 @@ func traverseObject(rt *goja.Runtime, src goja.Value, fields ...string) (goja.Va
 		obj = src.ToObject(rt)
 		if isNullish(obj) {
 			return nil, NewError(
-				0,
 				TypeError,
 				fmt.Sprintf("field %s is not an Object", strings.Join(fields[:idx+1], ".")),
 			)

--- a/webcrypto/hmac.go
+++ b/webcrypto/hmac.go
@@ -45,7 +45,7 @@ func newHmacKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Val
 	// and throw an error if it's not present.
 	hashValue, err := traverseObject(rt, params, "hash")
 	if err != nil {
-		return nil, NewError(0, SyntaxError, "could not get hash from algorithm parameter")
+		return nil, NewError(SyntaxError, "could not get hash from algorithm parameter")
 	}
 
 	// Although the specification doesn't explicitly ask us to do so, we
@@ -89,7 +89,7 @@ func (hkgp *HmacKeyGenParams) GenerateKey(
 		case SignCryptoKeyUsage, VerifyCryptoKeyUsage:
 			continue
 		default:
-			return nil, NewError(0, SyntaxError, "invalid key usage: "+usage)
+			return nil, NewError(SyntaxError, "invalid key usage: "+usage)
 		}
 	}
 
@@ -110,19 +110,19 @@ func (hkgp *HmacKeyGenParams) GenerateKey(
 		default:
 			// This case should never happen, as the normalization algorithm
 			// should have thrown an error if the hash algorithm is invalid.
-			return nil, NewError(0, ImplementationError, "invalid hash algorithm: "+hkgp.Hash.Name)
+			return nil, NewError(ImplementationError, "invalid hash algorithm: "+hkgp.Hash.Name)
 		}
 	}
 
 	if hkgp.Length.Int64 == 0 {
-		return nil, NewError(0, OperationError, "algorithm's length cannot be 0")
+		return nil, NewError(OperationError, "algorithm's length cannot be 0")
 	}
 
 	// 3.
 	randomKey := make([]byte, hkgp.Length.Int64/8)
 	if _, err := rand.Read(randomKey); err != nil {
 		// 4.
-		return nil, NewError(0, OperationError, "failed to generate random key; reason:  "+err.Error())
+		return nil, NewError(OperationError, "failed to generate random key; reason:  "+err.Error())
 	}
 
 	// 5.
@@ -169,13 +169,13 @@ type HmacKeyAlgorithm struct {
 func exportHmacKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
 	// 1.
 	if ck.handle == nil {
-		return nil, NewError(0, OperationError, "key data is not accesible")
+		return nil, NewError(OperationError, "key data is not accesible")
 	}
 
 	// 2.
 	bits, ok := ck.handle.([]byte)
 	if !ok {
-		return nil, NewError(0, OperationError, "key underlying data is not of the correct type")
+		return nil, NewError(OperationError, "key underlying data is not of the correct type")
 	}
 
 	// 4.
@@ -184,7 +184,7 @@ func exportHmacKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
 		return bits, nil
 	default:
 		// FIXME: note that we do not support JWK format, yet #37.
-		return nil, NewError(0, NotSupportedError, "unsupported key format "+format)
+		return nil, NewError(NotSupportedError, "unsupported key format "+format)
 	}
 }
 
@@ -192,7 +192,7 @@ func exportHmacKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
 func (hka *HmacKeyAlgorithm) HashFn() (func() hash.Hash, error) {
 	hashFn, ok := getHashFn(hka.Hash.Name)
 	if !ok {
-		return nil, NewError(0, NotSupportedError, fmt.Sprintf("unsupported key hash algorithm %q", hka.Hash.Name))
+		return nil, NewError(NotSupportedError, fmt.Sprintf("unsupported key hash algorithm %q", hka.Hash.Name))
 	}
 
 	return hashFn, nil
@@ -224,7 +224,7 @@ func newHmacImportParams(rt *goja.Runtime, normalized Algorithm, params goja.Val
 	// and throw an error if it's not present.
 	hashValue, err := traverseObject(rt, params, "hash")
 	if err != nil {
-		return nil, NewError(0, SyntaxError, "could not get hash from algorithm parameter")
+		return nil, NewError(SyntaxError, "could not get hash from algorithm parameter")
 	}
 
 	// Although the specification doesn't explicitly ask us to do so, we
@@ -269,7 +269,7 @@ func (hip *HmacImportParams) ImportKey(
 		case SignCryptoKeyUsage, VerifyCryptoKeyUsage:
 			continue
 		default:
-			return nil, NewError(0, SyntaxError, "invalid key usage: "+usage)
+			return nil, NewError(SyntaxError, "invalid key usage: "+usage)
 		}
 	}
 
@@ -281,23 +281,23 @@ func (hip *HmacImportParams) ImportKey(
 	case RawKeyFormat:
 		hash = KeyAlgorithm{Algorithm{Name: hip.Hash.Name}}
 	default:
-		return nil, NewError(0, NotSupportedError, "unsupported key format "+format)
+		return nil, NewError(NotSupportedError, "unsupported key format "+format)
 	}
 
 	// 5. 6.
 	length := int64(len(keyData) * 8)
 	if length == 0 {
-		return nil, NewError(0, DataError, "key length cannot be 0")
+		return nil, NewError(DataError, "key length cannot be 0")
 	}
 
 	// 7.
 	if hip.Length.Valid {
 		if hip.Length.Int64 > length {
-			return nil, NewError(0, DataError, "key length cannot be greater than the length of the imported data")
+			return nil, NewError(DataError, "key length cannot be greater than the length of the imported data")
 		}
 
 		if hip.Length.Int64 < length {
-			return nil, NewError(0, DataError, "key length cannot be less than the length of the imported data")
+			return nil, NewError(DataError, "key length cannot be less than the length of the imported data")
 		}
 
 		length = hip.Length.Int64

--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -56,7 +56,7 @@ func (sc *SubtleCrypto) Encrypt(algorithm, key, data goja.Value) *goja.Promise {
 
 	var ck CryptoKey
 	if err = rt.ExportTo(key, &ck); err != nil {
-		reject(NewError(0, TypeError, "key argument does hold not a valid CryptoKey object"))
+		reject(NewError(TypeError, "key argument does hold not a valid CryptoKey object"))
 		return promise
 	}
 
@@ -68,7 +68,7 @@ func (sc *SubtleCrypto) Encrypt(algorithm, key, data goja.Value) *goja.Promise {
 
 	// 8.
 	if normalized.Name != keyAlgorithmNameValue.String() {
-		reject(NewError(0, InvalidAccessError, "algorithm name does not match key algorithm name"))
+		reject(NewError(InvalidAccessError, "algorithm name does not match key algorithm name"))
 		return promise
 	}
 
@@ -81,7 +81,7 @@ func (sc *SubtleCrypto) Encrypt(algorithm, key, data goja.Value) *goja.Promise {
 	go func() {
 		// 9.
 		if !ck.ContainsUsage(EncryptCryptoKeyUsage) {
-			reject(NewError(0, InvalidAccessError, "key does not contain the 'encrypt' usage"))
+			reject(NewError(InvalidAccessError, "key does not contain the 'encrypt' usage"))
 			return
 		}
 
@@ -99,7 +99,7 @@ func (sc *SubtleCrypto) Encrypt(algorithm, key, data goja.Value) *goja.Promise {
 			resolve(rt.NewArrayBuffer(ciphertext))
 			return
 		default:
-			reject(NewError(0, NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalized.Name)))
+			reject(NewError(NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalized.Name)))
 			return
 		}
 	}()
@@ -148,7 +148,7 @@ func (sc *SubtleCrypto) Decrypt(algorithm, key, data goja.Value) *goja.Promise {
 
 	var ck CryptoKey
 	if err = rt.ExportTo(key, &ck); err != nil {
-		reject(NewError(0, InvalidAccessError, "key argument does hold not a valid CryptoKey object"))
+		reject(NewError(InvalidAccessError, "key argument does hold not a valid CryptoKey object"))
 		return promise
 	}
 
@@ -160,7 +160,7 @@ func (sc *SubtleCrypto) Decrypt(algorithm, key, data goja.Value) *goja.Promise {
 
 	// 8.
 	if normalized.Name != keyAlgorithmNameValue.String() {
-		reject(NewError(0, InvalidAccessError, "algorithm name does not match key algorithm name"))
+		reject(NewError(InvalidAccessError, "algorithm name does not match key algorithm name"))
 		return promise
 	}
 
@@ -173,7 +173,7 @@ func (sc *SubtleCrypto) Decrypt(algorithm, key, data goja.Value) *goja.Promise {
 	go func() {
 		// 9.
 		if !ck.ContainsUsage(DecryptCryptoKeyUsage) {
-			reject(NewError(0, InvalidAccessError, "key does not contain the 'decrypt' usage"))
+			reject(NewError(InvalidAccessError, "key does not contain the 'decrypt' usage"))
 			return
 		}
 
@@ -190,7 +190,7 @@ func (sc *SubtleCrypto) Decrypt(algorithm, key, data goja.Value) *goja.Promise {
 
 			resolve(rt.NewArrayBuffer(plaintext))
 		default:
-			reject(NewError(0, NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalized.Name)))
+			reject(NewError(NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalized.Name)))
 		}
 	}()
 
@@ -238,7 +238,7 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data goja.Value) *goja.Promise {
 
 	var ck CryptoKey
 	if err = rt.ExportTo(key, &ck); err != nil {
-		reject(NewError(0, InvalidAccessError, "key argument does hold not a valid CryptoKey object"))
+		reject(NewError(InvalidAccessError, "key argument does hold not a valid CryptoKey object"))
 		return promise
 	}
 
@@ -251,13 +251,13 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data goja.Value) *goja.Promise {
 	go func() {
 		// 8.
 		if normalized.Name != keyAlgorithmNameValue.String() {
-			reject(NewError(0, InvalidAccessError, "algorithm name does not match key algorithm name"))
+			reject(NewError(InvalidAccessError, "algorithm name does not match key algorithm name"))
 			return
 		}
 
 		// 9.
 		for !ck.ContainsUsage(SignCryptoKeyUsage) {
-			reject(NewError(0, InvalidAccessError, "key does not contain the 'sign' usage"))
+			reject(NewError(InvalidAccessError, "key does not contain the 'sign' usage"))
 			return
 		}
 
@@ -266,13 +266,13 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data goja.Value) *goja.Promise {
 		case HMAC:
 			keyAlgorithm, ok := ck.Algorithm.(HmacKeyAlgorithm)
 			if !ok {
-				reject(NewError(0, InvalidAccessError, "key algorithm does not describe a HMAC key"))
+				reject(NewError(InvalidAccessError, "key algorithm does not describe a HMAC key"))
 				return
 			}
 
 			keyHandle, ok := ck.handle.([]byte)
 			if !ok {
-				reject(NewError(0, InvalidAccessError, "key handle is of incorrect type"))
+				reject(NewError(InvalidAccessError, "key handle is of incorrect type"))
 				return
 			}
 
@@ -290,7 +290,7 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data goja.Value) *goja.Promise {
 
 			resolve(rt.NewArrayBuffer(mac))
 		default:
-			reject(NewError(0, NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalized.Name)))
+			reject(NewError(NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalized.Name)))
 		}
 	}()
 
@@ -347,7 +347,7 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data goja.Value) *goja
 
 	var ck CryptoKey
 	if err = rt.ExportTo(key, &ck); err != nil {
-		reject(NewError(0, InvalidAccessError, "key argument does hold not a valid CryptoKey object"))
+		reject(NewError(InvalidAccessError, "key argument does hold not a valid CryptoKey object"))
 		return promise
 	}
 
@@ -360,13 +360,13 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data goja.Value) *goja
 	go func() {
 		// 9.
 		if normalizedAlgorithm.Name != keyAlgorithmNameValue.String() {
-			reject(NewError(0, InvalidAccessError, "algorithm name does not match key algorithm name"))
+			reject(NewError(InvalidAccessError, "algorithm name does not match key algorithm name"))
 			return
 		}
 
 		// 10.
 		for !ck.ContainsUsage(VerifyCryptoKeyUsage) {
-			reject(NewError(0, InvalidAccessError, "key does not contain the 'sign' usage"))
+			reject(NewError(InvalidAccessError, "key does not contain the 'sign' usage"))
 			return
 		}
 
@@ -374,13 +374,13 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data goja.Value) *goja
 		case HMAC:
 			keyAlgorithm, ok := ck.Algorithm.(HmacKeyAlgorithm)
 			if !ok {
-				reject(NewError(0, InvalidAccessError, "key algorithm does not describe a HMAC key"))
+				reject(NewError(InvalidAccessError, "key algorithm does not describe a HMAC key"))
 				return
 			}
 
 			keyHandle, ok := ck.handle.([]byte)
 			if !ok {
-				reject(NewError(0, InvalidAccessError, "key handle is of incorrect type"))
+				reject(NewError(InvalidAccessError, "key handle is of incorrect type"))
 				return
 			}
 
@@ -395,7 +395,7 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data goja.Value) *goja
 
 			resolve(hmac.Equal(signatureData, hasher.Sum(nil)))
 		default:
-			reject(NewError(0, NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalizedAlgorithm.Name)))
+			reject(NewError(NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalizedAlgorithm.Name)))
 		}
 	}()
 
@@ -470,7 +470,7 @@ func (sc *SubtleCrypto) Digest(algorithm goja.Value, data goja.Value) *goja.Prom
 		hashFn, ok := getHashFn(normalized.Name)
 		if !ok {
 			// 7.
-			reject(NewError(0, NotSupportedError, "unsupported algorithm: "+normalized.Name))
+			reject(NewError(NotSupportedError, "unsupported algorithm: "+normalized.Name))
 			return
 		}
 
@@ -532,7 +532,7 @@ func (sc *SubtleCrypto) GenerateKey(algorithm goja.Value, extractable bool, keyU
 		isPrivateKey := result.Type == PrivateCryptoKeyType
 		isUsagesEmpty := len(result.Usages) == 0
 		if (isSecretKey || isPrivateKey) && isUsagesEmpty {
-			reject(NewError(0, SyntaxError, "usages cannot not be empty for a secret or private CryptoKey"))
+			reject(NewError(SyntaxError, "usages cannot not be empty for a secret or private CryptoKey"))
 			return
 		}
 
@@ -681,7 +681,7 @@ func (sc *SubtleCrypto) ImportKey(
 		isPrivateKey := result.Type == PrivateCryptoKeyType
 		isUsagesEmpty := len(keyUsages) == 0
 		if (isSecretKey || isPrivateKey) && isUsagesEmpty {
-			reject(NewError(0, SyntaxError, "usages cannot not be empty for a secret or private CryptoKey"))
+			reject(NewError(SyntaxError, "usages cannot not be empty for a secret or private CryptoKey"))
 			return
 		}
 
@@ -721,32 +721,32 @@ func (sc *SubtleCrypto) ExportKey(format KeyFormat, key goja.Value) *goja.Promis
 	var algorithm Algorithm
 	algValue := key.ToObject(rt).Get("algorithm")
 	if err := rt.ExportTo(algValue, &algorithm); err != nil {
-		reject(NewError(0, SyntaxError, "key is not a valid CryptoKey"))
+		reject(NewError(SyntaxError, "key is not a valid CryptoKey"))
 		return promise
 	}
 
 	ck, ok := key.Export().(*CryptoKey)
 	if !ok {
-		reject(NewError(0, ImplementationError, "unable to extract CryptoKey"))
+		reject(NewError(ImplementationError, "unable to extract CryptoKey"))
 		return promise
 	}
 
 	keyAlgorithmName := key.ToObject(rt).Get("algorithm").ToObject(rt).Get("name").String()
 	if algorithm.Name != keyAlgorithmName {
-		reject(NewError(0, InvalidAccessError, "algorithm name does not match key algorithm name"))
+		reject(NewError(InvalidAccessError, "algorithm name does not match key algorithm name"))
 		return promise
 	}
 
 	go func() {
 		// 5.
 		if !isRegisteredAlgorithm(algorithm.Name, OperationIdentifierExportKey) {
-			reject(NewError(0, NotSupportedError, "unsupported algorithm "+algorithm.Name))
+			reject(NewError(NotSupportedError, "unsupported algorithm "+algorithm.Name))
 			return
 		}
 
 		// 6.
 		if !ck.Extractable {
-			reject(NewError(0, InvalidAccessError, "the key is not extractable"))
+			reject(NewError(InvalidAccessError, "the key is not extractable"))
 			return
 		}
 
@@ -767,7 +767,7 @@ func (sc *SubtleCrypto) ExportKey(format KeyFormat, key goja.Value) *goja.Promis
 				return
 			}
 		default:
-			reject(NewError(0, NotSupportedError, "unsupported algorithm "+keyAlgorithmName))
+			reject(NewError(NotSupportedError, "unsupported algorithm "+keyAlgorithmName))
 			return
 		}
 


### PR DESCRIPTION
The `Error` type `code` field was a legacy attribute that we did not use in the end. This PR removes the attribute, and adjusts the `NewError` constructor accordingly.

I have separated the actual change and all the codebase adjustments it triggered in two separate commits for convenience.

This closes #33