### PR TITLE
Refactor bits/bytes conversion

### DIFF
--- a/webcrypto/types.go
+++ b/webcrypto/types.go
@@ -6,6 +6,22 @@ import (
 	"github.com/dop251/goja"
 )
 
+// bitLength is a type alias for the length of a bits collection.
+type bitLength int
+
+// asByteLength returns the length of the bits collection in bytes.
+func (b bitLength) asByteLength() byteLength {
+	return byteLength(b) / 8
+}
+
+// byteLength is a type alias for the length of a byte slice.
+type byteLength int
+
+// asBitLength returns the length of the byte slice in bits.
+func (b byteLength) asBitLength() bitLength {
+	return bitLength(b) * 8
+}
+
 // ToBytes tries to return a byte slice from compatible types.
 func ToBytes(data interface{}) ([]byte, error) {
 	switch dt := data.(type) {


### PR DESCRIPTION
This PR address #36 and introduces two new type aliases: `bitLength` and `byteLength` helping make conversion from bytes length to bits and vice versa, more explicit, readable, and less error prone.

closes #36