### PR TITLE
Refactor naming to follow Go naming conventions

### DIFF
--- a/webcrypto/aes.go
+++ b/webcrypto/aes.go
@@ -10,25 +10,25 @@ import (
 	"github.com/dop251/goja"
 )
 
-// AesKeyGenParams represents the object that should be passed as
+// AESKeyGenParams represents the object that should be passed as
 // the algorithm parameter into `SubtleCrypto.generateKey`, when generating
 // an AES key: that is, when the algorithm is identified as any
 // of AES-CBC, AES-CTR, AES-GCM, or AES-KW.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-keygen-params
-type AesKeyGenParams struct {
+type AESKeyGenParams struct {
 	Algorithm
 
 	// The length, in bits, of the key.
 	Length int64 `json:"length"`
 }
 
-// newAesKeyGenParams creates a new AesKeyGenParams object, from the
+// newAESKeyGenParams creates a new AESKeyGenParams object, from the
 // normalized algorithm, and the algorithm parameters.
 //
 // It handles the logic involved in handling the `length` attribute,
 // which is not part of the normalized algorithm.
-func newAesKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Value) (*AesKeyGenParams, error) {
+func newAESKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Value) (*AESKeyGenParams, error) {
 	// We extract the length attribute from the params object, as it's not
 	// part of the normalized algorithm, and as accessing the runtime from the
 	// callback below could lead to a race condition.
@@ -39,7 +39,7 @@ func newAesKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Valu
 
 	algorithmLength := algorithmLengthValue.ToInteger()
 
-	return &AesKeyGenParams{
+	return &AESKeyGenParams{
 		Algorithm: normalized,
 		Length:    algorithmLength,
 	}, nil
@@ -49,7 +49,7 @@ func newAesKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Valu
 // described in the specification.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-keygen-params
-func (akgp *AesKeyGenParams) GenerateKey(
+func (akgp *AESKeyGenParams) GenerateKey(
 	extractable bool,
 	keyUsages []CryptoKeyUsage,
 ) (*CryptoKey, error) {
@@ -84,7 +84,7 @@ func (akgp *AesKeyGenParams) GenerateKey(
 	// 5. 6. 7. 8. 9.
 	key := CryptoKey{}
 	key.Type = SecretCryptoKeyType
-	key.Algorithm = AesKeyAlgorithm{
+	key.Algorithm = AESKeyAlgorithm{
 		Algorithm: akgp.Algorithm,
 		Length:    akgp.Length,
 	}
@@ -102,13 +102,13 @@ func (akgp *AesKeyGenParams) GenerateKey(
 	return &key, nil
 }
 
-// Ensure that AesKeyGenParams implements the KeyGenerator interface.
-var _ KeyGenerator = &AesKeyGenParams{}
+// Ensure that AESKeyGenParams implements the KeyGenerator interface.
+var _ KeyGenerator = &AESKeyGenParams{}
 
-// AesKeyAlgorithm is the algorithm for AES keys as defined in the [specification].
+// AESKeyAlgorithm is the algorithm for AES keys as defined in the [specification].
 //
-// [specification]: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesKeyAlgorithm
-type AesKeyAlgorithm struct {
+// [specification]: https://www.w3.org/TR/WebCryptoAPI/#dfn-AESKeyAlgorithm
+type AESKeyAlgorithm struct {
 	Algorithm
 
 	Length int64 `json:"length"`
@@ -141,15 +141,15 @@ func exportAESKey(key *CryptoKey, format KeyFormat) ([]byte, error) {
 	}
 }
 
-// aesImportParams is an internal placeholder struct for AES import parameters.
+// AESImportParams is an internal placeholder struct for AES import parameters.
 // Although not described by the specification, we define it to be able to implement
 // our internal KeyImporter interface.
-type aesImportParams struct {
+type AESImportParams struct {
 	Algorithm
 }
 
-func newAesImportParams(normalized Algorithm) *aesImportParams {
-	return &aesImportParams{
+func newAESImportParams(normalized Algorithm) *AESImportParams {
+	return &AESImportParams{
 		Algorithm: normalized,
 	}
 }
@@ -158,7 +158,7 @@ func newAesImportParams(normalized Algorithm) *aesImportParams {
 // It implements the KeyImporter interface.
 //
 // TODO @oleiade: support JWK format #37
-func (aip *aesImportParams) ImportKey(
+func (aip *AESImportParams) ImportKey(
 	format KeyFormat,
 	keyData []byte,
 	keyUsages []CryptoKeyUsage,
@@ -188,7 +188,7 @@ func (aip *aesImportParams) ImportKey(
 	}
 
 	key := &CryptoKey{
-		Algorithm: AesKeyAlgorithm{
+		Algorithm: AESKeyAlgorithm{
 			Algorithm: aip.Algorithm,
 			Length:    int64(len(keyData) * 8),
 		},
@@ -199,17 +199,17 @@ func (aip *aesImportParams) ImportKey(
 	return key, nil
 }
 
-// Ensure that aesImportParams implements the KeyImporter interface.
-var _ KeyImporter = &aesImportParams{}
+// Ensure that AESImportParams implements the KeyImporter interface.
+var _ KeyImporter = &AESImportParams{}
 
-// AesCbcParams represents the object that should be passed as the algorithm parameter
+// AESCBCParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.Encrypt`, `SubtleCrypto.Decrypt`, `SubtleCrypto.WrapKey`, or
 // `SubtleCrypto.UnwrapKey`, when using the AES-CBC algorithm.
 //
 // As defined in the [specification].
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-cbc-params
-type AesCbcParams struct {
+type AESCBCParams struct {
 	Algorithm
 
 	// Name should be set to AES-CBC.
@@ -225,7 +225,7 @@ type AesCbcParams struct {
 // Implements the WebCryptoAPI `encrypt` method's [specification] for the AES-CBC algorithm.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-cbc
-func (acp *AesCbcParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error) {
+func (acp *AESCBCParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error) {
 	// 1.
 	// Note that aes.BlockSize stands for the `k` variable as per the specification.
 	if len(acp.Iv) != aes.BlockSize {
@@ -260,7 +260,7 @@ func (acp *AesCbcParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error
 // Implements the WebCryptoAPI's `decrypt` method's [specification] for the AES-CBC algorithm.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-cbc
-func (acp *AesCbcParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, error) {
+func (acp *AESCBCParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, error) {
 	// 1.
 	if len(acp.Iv) != aes.BlockSize {
 		return nil, NewError(OperationError, "iv length is invalid, should be 16 bytes")
@@ -298,17 +298,17 @@ func (acp *AesCbcParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, erro
 	return plaintext, nil
 }
 
-// Ensure that AesCbcParams implements the EncryptDecrypter interface.
-var _ EncryptDecrypter = &AesCbcParams{}
+// Ensure that AESCBCParams implements the EncryptDecrypter interface.
+var _ EncryptDecrypter = &AESCBCParams{}
 
-// AesCtrParams represents the object that should be passed as the algorithm parameter
+// AESCTRParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.Encrypt`, `SubtleCrypto.Decrypt`, `SubtleCrypto.WrapKey`, or
 // `SubtleCrypto.UnwrapKey`, when using the AES-CTR algorithm.
 //
 // As defined in the [specification].
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-ctr-params
-type AesCtrParams struct {
+type AESCTRParams struct {
 	Algorithm
 
 	// Counter holds (an ArrayBuffer, a TypedArray, or a DataView) the initial value of the counter block.
@@ -332,7 +332,7 @@ type AesCtrParams struct {
 // Implements the WebCryptoAPI's `encrypt` method's [specification] for the AES-CTR algorithm.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-ctr
-func (acp *AesCtrParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error) {
+func (acp *AESCTRParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error) {
 	// 1.
 	// Note that aes.BlockSize stands for the `k` variable as per the specification.
 	if len(acp.Counter) != aes.BlockSize {
@@ -366,7 +366,7 @@ func (acp *AesCtrParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error
 // Implements the WebCryptoAPI's `decrypt` method's [specification] for the AES-CTR algorithm.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-ctr
-func (acp *AesCtrParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, error) {
+func (acp *AESCTRParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, error) {
 	// 1.
 	if len(acp.Counter) != aes.BlockSize {
 		return nil, NewError(OperationError, "counter length is invalid, should be 16 bytes")
@@ -395,16 +395,16 @@ func (acp *AesCtrParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, erro
 	return plaintext, nil
 }
 
-// Ensure that AesCtrParams implements the EncryptDecrypter interface.
-var _ EncryptDecrypter = &AesCtrParams{}
+// Ensure that AESCTRParams implements the EncryptDecrypter interface.
+var _ EncryptDecrypter = &AESCTRParams{}
 
-// AesGcmParams represents the object that should be passed as the algorithm parameter
+// AESGCMParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.Encrypt`, `SubtleCrypto.Decrypt`, `SubtleCrypto.WrapKey`, or
 // `SubtleCrypto.UnwrapKey`, when using the AES-GCM algorithm.
 // As defined in the [specification].
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-gcm-params
-type AesGcmParams struct {
+type AESGCMParams struct {
 	Algorithm
 
 	// Iv holds (an ArrayBuffer, a TypedArray, or a DataView) with the initialization vector.
@@ -450,11 +450,11 @@ type AesGcmParams struct {
 // Implements the WebCryptoAPI's `encrypt` method's [specification] for the AES-GCM algorithm.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-gcm
-func (agp *AesGcmParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error) {
+func (agp *AESGCMParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error) {
 	// 1.
 	// As described in section 8 of AES-GCM [NIST SP800-38D].
 	// [NIST SP800-38D] https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
-	if len(plaintext) > maxAesGcmPlaintextLength {
+	if len(plaintext) > maxAESGCMPlaintextLength {
 		return nil, NewError(OperationError, "plaintext length is too long")
 	}
 
@@ -472,7 +472,7 @@ func (agp *AesGcmParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error
 	// 3.
 	// As described in section 8 of AES-GCM [NIST SP800-38D].
 	// [NIST SP800-38D] https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
-	if agp.AdditionalData != nil && (uint64(len(agp.AdditionalData)) > maxAesGcmAdditionalDataLength) {
+	if agp.AdditionalData != nil && (uint64(len(agp.AdditionalData)) > maxAESGcmAdditionalDataLength) {
 		return nil, NewError(OperationError, "additional data length is too long")
 	}
 
@@ -524,7 +524,7 @@ func (agp *AesGcmParams) Encrypt(plaintext []byte, key CryptoKey) ([]byte, error
 // Implements the WebCryptoAPI's `decrypt` method's [specification] for the AES-GCM algorithm.
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#aes-gcm
-func (agp *AesGcmParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, error) {
+func (agp *AESGCMParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, error) {
 	// 1.
 	var tagLength int
 	if agp.TagLength == 0 {
@@ -549,12 +549,12 @@ func (agp *AesGcmParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, erro
 	}
 
 	// 3.
-	if len(agp.Iv) < 1 || uint64(len(agp.Iv)) > maxAesGcmIvLength {
+	if len(agp.Iv) < 1 || uint64(len(agp.Iv)) > maxAESGcmIvLength {
 		return nil, NewError(OperationError, "iv length is too long")
 	}
 
 	// 4.
-	if agp.AdditionalData != nil && uint64(len(agp.AdditionalData)) > maxAesGcmAdditionalDataLength {
+	if agp.AdditionalData != nil && uint64(len(agp.AdditionalData)) > maxAESGcmAdditionalDataLength {
 		return nil, NewError(OperationError, "additional data is too long")
 	}
 
@@ -585,23 +585,23 @@ func (agp *AesGcmParams) Decrypt(ciphertext []byte, key CryptoKey) ([]byte, erro
 	return plaintext, nil
 }
 
-// maxAesGcmPlaintextLength holds the value (2 ^ 39) - 256 as specified in
+// maxAESGCMPlaintextLength holds the value (2 ^ 39) - 256 as specified in
 // The [Web Crypto API spec] for the AES-GCM algorithm encryption operation.
 //
 // [Web Crypto API spec]: https://www.w3.org/TR/WebCryptoAPI/#aes-gcm-encryption-operation
-const maxAesGcmPlaintextLength int = 549755813632
+const maxAESGCMPlaintextLength int = 549755813632
 
-// maxAesGcmAdditionalDataLength holds the value 2 ^ 64 - 1 as specified in
+// maxAESGcmAdditionalDataLength holds the value 2 ^ 64 - 1 as specified in
 // the [Web Crypto API spec] for the AES-GCM algorithm encryption operation.
 //
 // [Web Crypto API spec]: https://www.w3.org/TR/WebCryptoAPI/#aes-gcm-encryption-operation
-const maxAesGcmAdditionalDataLength uint64 = 18446744073709551615
+const maxAESGcmAdditionalDataLength uint64 = 18446744073709551615
 
-// maxAesGcmIvLength holds the value 2 ^ 64 - 1 as specified in
+// maxAESGcmIvLength holds the value 2 ^ 64 - 1 as specified in
 // the [Web Crypto API spec] for the AES-GCM algorithm encryption operation.
 //
 // [Web Crypto API spec]: https://www.w3.org/TR/WebCryptoAPI/#aes-gcm-encryption-operation
-const maxAesGcmIvLength uint64 = 18446744073709551615
+const maxAESGcmIvLength uint64 = 18446744073709551615
 
 var (
 	// ErrInvalidBlockSize is returned when the given block size is invalid.

--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -60,17 +60,17 @@ const (
 type HashAlgorithmIdentifier = AlgorithmIdentifier
 
 const (
-	// Sha1 represents the SHA-1 algorithm.
-	Sha1 HashAlgorithmIdentifier = "SHA-1"
+	// SHA1 represents the SHA-1 algorithm.
+	SHA1 HashAlgorithmIdentifier = "SHA-1"
 
-	// Sha256 represents the SHA-256 algorithm.
-	Sha256 = "SHA-256"
+	// SHA256 represents the SHA-256 algorithm.
+	SHA256 = "SHA-256"
 
-	// Sha384 represents the SHA-384 algorithm.
-	Sha384 = "SHA-384"
+	// SHA384 represents the SHA-384 algorithm.
+	SHA384 = "SHA-384"
 
-	// Sha512 represents the SHA-512 algorithm.
-	Sha512 = "SHA-512"
+	// SHA512 represents the SHA-512 algorithm.
+	SHA512 = "SHA-512"
 )
 
 // OperationIdentifier represents the name of an operation.
@@ -185,5 +185,5 @@ func isAesAlgorithm(algorithmName string) bool {
 }
 
 func isHashAlgorithm(algorithmName string) bool {
-	return algorithmName == Sha1 || algorithmName == Sha256 || algorithmName == Sha384 || algorithmName == Sha512
+	return algorithmName == SHA1 || algorithmName == SHA256 || algorithmName == SHA384 || algorithmName == SHA512
 }

--- a/webcrypto/encryption.go
+++ b/webcrypto/encryption.go
@@ -38,13 +38,13 @@ func newEncryptDecrypter(
 
 	switch algorithm.Name {
 	case AESCbc:
-		ed = new(AesCbcParams)
+		ed = new(AESCBCParams)
 		paramsObjectName = "AesCbcParams"
 	case AESCtr:
-		ed = new(AesCtrParams)
+		ed = new(AESCTRParams)
 		paramsObjectName = "AesCtrParams"
 	case AESGcm:
-		ed = new(AesGcmParams)
+		ed = new(AESGCMParams)
 		paramsObjectName = "AesGcmParams"
 	default:
 		return nil, NewError(NotSupportedError, "unsupported algorithm")

--- a/webcrypto/hash.go
+++ b/webcrypto/hash.go
@@ -11,13 +11,13 @@ import (
 // hash.Hash instance.
 func getHashFn(name string) (func() hash.Hash, bool) {
 	switch name {
-	case Sha1:
+	case SHA1:
 		return crypto.SHA1.New, true
-	case Sha256:
+	case SHA256:
 		return crypto.SHA256.New, true
-	case Sha384:
+	case SHA384:
 		return crypto.SHA384.New, true
-	case Sha512:
+	case SHA512:
 		return crypto.SHA512.New, true
 	default:
 		return nil, false

--- a/webcrypto/hmac.go
+++ b/webcrypto/hmac.go
@@ -12,9 +12,9 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
-// HmacKeyGenParams represents the object that should be passed as the algorithm parameter
+// HMACKeyGenParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.GenerateKey`, when generating an HMAC key.
-type HmacKeyGenParams struct {
+type HMACKeyGenParams struct {
 	Algorithm
 
 	// Hash represents the name of the digest function to use. You can
@@ -30,7 +30,7 @@ type HmacKeyGenParams struct {
 	Length null.Int `json:"length"`
 }
 
-// newHmacKeyGenParams creates a new HmacKeyGenParams object, from the normalized
+// newHMACKeyGenParams creates a new HMACKeyGenParams object, from the normalized
 // algorithm, and the params parameters passed by the user.
 //
 // It handles the logic of extracting the hash algorithm from the params object,
@@ -39,7 +39,7 @@ type HmacKeyGenParams struct {
 // not present as described in the hmac `generateKey` [specification].
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#hmac-operations
-func newHmacKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Value) (*HmacKeyGenParams, error) {
+func newHMACKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Value) (*HMACKeyGenParams, error) {
 	// The specification doesn't explicitly tell us what to do if the
 	// hash field is not present, but we assume it's a mandatory field
 	// and throw an error if it's not present.
@@ -71,7 +71,7 @@ func newHmacKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Val
 		length = null.IntFrom(algorithmLengthValue.ToInteger())
 	}
 
-	return &HmacKeyGenParams{
+	return &HMACKeyGenParams{
 		Algorithm: normalized,
 		Hash:      normalizedHash,
 		Length:    length,
@@ -79,7 +79,7 @@ func newHmacKeyGenParams(rt *goja.Runtime, normalized Algorithm, params goja.Val
 }
 
 // GenerateKey generates a new HMAC key.
-func (hkgp *HmacKeyGenParams) GenerateKey(
+func (hkgp *HMACKeyGenParams) GenerateKey(
 	extractable bool,
 	keyUsages []CryptoKeyUsage,
 ) (*CryptoKey, error) {
@@ -129,7 +129,7 @@ func (hkgp *HmacKeyGenParams) GenerateKey(
 	key := &CryptoKey{Type: SecretCryptoKeyType, handle: randomKey}
 
 	// 6.
-	algorithm := HmacKeyAlgorithm{}
+	algorithm := HMACKeyAlgorithm{}
 
 	// 7.
 	algorithm.Name = HMAC
@@ -152,11 +152,11 @@ func (hkgp *HmacKeyGenParams) GenerateKey(
 	return key, nil
 }
 
-// Ensure that HmacKeyGenParams implements the KeyGenerator interface.
-var _ KeyGenerator = &HmacKeyGenParams{}
+// Ensure that HMACKeyGenParams implements the KeyGenerator interface.
+var _ KeyGenerator = &HMACKeyGenParams{}
 
-// HmacKeyAlgorithm represents the algorithm of an HMAC key.
-type HmacKeyAlgorithm struct {
+// HMACKeyAlgorithm represents the algorithm of an HMAC key.
+type HMACKeyAlgorithm struct {
 	KeyAlgorithm
 
 	// Hash represents the inner hash function to use.
@@ -166,7 +166,7 @@ type HmacKeyAlgorithm struct {
 	Length int64 `json:"length"`
 }
 
-func exportHmacKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
+func exportHMACKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
 	// 1.
 	if ck.handle == nil {
 		return nil, NewError(OperationError, "key data is not accesible")
@@ -189,7 +189,7 @@ func exportHmacKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
 }
 
 // HashFn returns the hash function to use for the HMAC key.
-func (hka *HmacKeyAlgorithm) HashFn() (func() hash.Hash, error) {
+func (hka *HMACKeyAlgorithm) HashFn() (func() hash.Hash, error) {
 	hashFn, ok := getHashFn(hka.Hash.Name)
 	if !ok {
 		return nil, NewError(NotSupportedError, fmt.Sprintf("unsupported key hash algorithm %q", hka.Hash.Name))
@@ -198,9 +198,9 @@ func (hka *HmacKeyAlgorithm) HashFn() (func() hash.Hash, error) {
 	return hashFn, nil
 }
 
-// HmacImportParams represents the object that should be passed as the algorithm parameter
+// HMACImportParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.GenerateKey`, when generating an HMAC key.
-type HmacImportParams struct {
+type HMACImportParams struct {
 	Algorithm
 
 	// Hash represents the name of the digest function to use. You can
@@ -216,9 +216,9 @@ type HmacImportParams struct {
 	Length null.Int `json:"length"`
 }
 
-// newHmacImportParams creates a new HmacImportParams object from the given
+// newHMACImportParams creates a new HMACImportParams object from the given
 // algorithm and params objects.
-func newHmacImportParams(rt *goja.Runtime, normalized Algorithm, params goja.Value) (*HmacImportParams, error) {
+func newHMACImportParams(rt *goja.Runtime, normalized Algorithm, params goja.Value) (*HMACImportParams, error) {
 	// The specification doesn't explicitly tell us what to do if the
 	// hash field is not present, but we assume it's a mandatory field
 	// and throw an error if it's not present.
@@ -250,7 +250,7 @@ func newHmacImportParams(rt *goja.Runtime, normalized Algorithm, params goja.Val
 		length = null.IntFrom(algorithmLengthValue.ToInteger())
 	}
 
-	return &HmacImportParams{
+	return &HMACImportParams{
 		Algorithm: normalized,
 		Hash:      normalizedHash,
 		Length:    length,
@@ -258,7 +258,7 @@ func newHmacImportParams(rt *goja.Runtime, normalized Algorithm, params goja.Val
 }
 
 // ImportKey imports a key from raw key data. It implements the KeyImporter interface.
-func (hip *HmacImportParams) ImportKey(
+func (hip *HMACImportParams) ImportKey(
 	format KeyFormat,
 	keyData []byte,
 	keyUsages []CryptoKeyUsage,
@@ -310,7 +310,7 @@ func (hip *HmacImportParams) ImportKey(
 	}
 
 	// 9.
-	algorithm := HmacKeyAlgorithm{}
+	algorithm := HMACKeyAlgorithm{}
 
 	// 10.
 	algorithm.Name = HMAC
@@ -327,5 +327,5 @@ func (hip *HmacImportParams) ImportKey(
 	return &key, nil
 }
 
-// Ensure that HmacImportParams implements the KeyImporter interface.
-var _ KeyImporter = &HmacImportParams{}
+// Ensure that HMACImportParams implements the KeyImporter interface.
+var _ KeyImporter = &HMACImportParams{}

--- a/webcrypto/hmac.go
+++ b/webcrypto/hmac.go
@@ -99,13 +99,13 @@ func (hkgp *HMACKeyGenParams) GenerateKey(
 	// callback below could lead to a race condition.
 	if !hkgp.Length.Valid {
 		switch hkgp.Hash.Name {
-		case Sha1:
+		case SHA1:
 			hkgp.Length = null.IntFrom(sha1.BlockSize * 8)
-		case Sha256:
+		case SHA256:
 			hkgp.Length = null.IntFrom(sha256.BlockSize * 8)
-		case Sha384:
+		case SHA384:
 			hkgp.Length = null.IntFrom(sha512.BlockSize * 8)
-		case Sha512:
+		case SHA512:
 			hkgp.Length = null.IntFrom(sha512.BlockSize * 8)
 		default:
 			// This case should never happen, as the normalization algorithm

--- a/webcrypto/key.go
+++ b/webcrypto/key.go
@@ -125,7 +125,7 @@ func newKeyGenerator(rt *goja.Runtime, normalized Algorithm, params goja.Value) 
 	case AESCbc, AESCtr, AESGcm, AESKw:
 		kg, err = newAESKeyGenParams(rt, normalized, params)
 	case HMAC:
-		kg, err = newHmacKeyGenParams(rt, normalized, params)
+		kg, err = newHMACKeyGenParams(rt, normalized, params)
 	}
 
 	if err != nil {
@@ -149,7 +149,7 @@ func newKeyImporter(rt *goja.Runtime, normalized Algorithm, params goja.Value) (
 	case AESCbc, AESCtr, AESGcm, AESKw:
 		ki = newAESImportParams(normalized)
 	case HMAC:
-		ki, err = newHmacImportParams(rt, normalized, params)
+		ki, err = newHMACImportParams(rt, normalized, params)
 	}
 
 	if err != nil {

--- a/webcrypto/key.go
+++ b/webcrypto/key.go
@@ -123,7 +123,7 @@ func newKeyGenerator(rt *goja.Runtime, normalized Algorithm, params goja.Value) 
 
 	switch normalized.Name {
 	case AESCbc, AESCtr, AESGcm, AESKw:
-		kg, err = newAesKeyGenParams(rt, normalized, params)
+		kg, err = newAESKeyGenParams(rt, normalized, params)
 	case HMAC:
 		kg, err = newHmacKeyGenParams(rt, normalized, params)
 	}
@@ -147,7 +147,7 @@ func newKeyImporter(rt *goja.Runtime, normalized Algorithm, params goja.Value) (
 
 	switch normalized.Name {
 	case AESCbc, AESCtr, AESGcm, AESKw:
-		ki = newAesImportParams(normalized)
+		ki = newAESImportParams(normalized)
 	case HMAC:
 		ki, err = newHmacImportParams(rt, normalized, params)
 	}

--- a/webcrypto/params.go
+++ b/webcrypto/params.go
@@ -10,18 +10,6 @@ type From[Input, Output any] interface {
 	From(Input) (Output, error)
 }
 
-// AESKeyGenParams represents the object that should be passed as
-// the algorithm parameter into `SubtleCrypto.generateKey`, when generating
-// an AES key: that is, when the algorithm is identified as any
-// of AES-CBC, AES-CTR, AES-GCM, or AES-KW.
-type AESKeyGenParams struct {
-	// Name should be set to `AES-CBC`, `AES-CTR`, `AES-GCM`, or `AES-KW`.
-	Name AlgorithmIdentifier
-
-	// Length holds (a Number) the length of the key, in bits.
-	Length int
-}
-
 // AESKwParams represents the object that should be passed as the algorithm parameter
 // into `SubtleCrypto.Encrypt`, `SubtleCrypto.Decrypt`, `SubtleCrypto.WrapKey`, or
 // `SubtleCrypto.UnwrapKey`, when using the AES-KW algorithm.

--- a/webcrypto/params.go
+++ b/webcrypto/params.go
@@ -95,17 +95,6 @@ type HMACSignatureParams struct {
 	Name AlgorithmIdentifier
 }
 
-// HMACImportParams represents the object that should be passed as the
-// algorithm parameter into `SubtleCrypto.ImportKey` or `SubtleCrypto.UnwrapKey`, when
-// generating a key for the HMAC algorithm.
-type HMACImportParams struct {
-	// Name should be set to AlgorithmKindHmac.
-	Name AlgorithmIdentifier
-
-	// Hash represents the name of the digest function to use.
-	Hash AlgorithmIdentifier
-}
-
 // PBKDF2Params represents the object that should be passed as the algorithm
 // parameter into `SubtleCrypto.DeriveKey`, when using the PBKDF2 algorithm.
 type PBKDF2Params struct {

--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -264,7 +264,7 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data goja.Value) *goja.Promise {
 		// 10.
 		switch normalized.Name {
 		case HMAC:
-			keyAlgorithm, ok := ck.Algorithm.(HmacKeyAlgorithm)
+			keyAlgorithm, ok := ck.Algorithm.(HMACKeyAlgorithm)
 			if !ok {
 				reject(NewError(InvalidAccessError, "key algorithm does not describe a HMAC key"))
 				return
@@ -372,7 +372,7 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data goja.Value) *goja
 
 		switch normalizedAlgorithm.Name {
 		case HMAC:
-			keyAlgorithm, ok := ck.Algorithm.(HmacKeyAlgorithm)
+			keyAlgorithm, ok := ck.Algorithm.(HMACKeyAlgorithm)
 			if !ok {
 				reject(NewError(InvalidAccessError, "key algorithm does not describe a HMAC key"))
 				return
@@ -744,7 +744,7 @@ func (sc *SubtleCrypto) ExportKey(format KeyFormat, key goja.Value) *goja.Promis
 				return
 			}
 		case HMAC:
-			result, err = exportHmacKey(ck, format)
+			result, err = exportHMACKey(ck, format)
 			if err != nil {
 				reject(err)
 				return


### PR DESCRIPTION
This PR renames most structs and constants involving an acronym or cipher name following the Go convention of holding to acronyms as capitalised strings.

closes #39 