### PR TITLE
Fix #55 and drop usage of `goja.SetTagFieldMapper` in the module code

### DIFF
--- a/webcrypto/aes.go
+++ b/webcrypto/aes.go
@@ -20,7 +20,7 @@ type AESKeyGenParams struct {
 	Algorithm
 
 	// The length, in bits, of the key.
-	Length bitLength `json:"length"`
+	Length bitLength `js:"length"`
 }
 
 // newAESKeyGenParams creates a new AESKeyGenParams object, from the
@@ -111,7 +111,7 @@ var _ KeyGenerator = &AESKeyGenParams{}
 type AESKeyAlgorithm struct {
 	Algorithm
 
-	Length int64 `json:"length"`
+	Length int64 `js:"length"`
 }
 
 // exportAESKey exports an AES key to its raw representation.
@@ -213,12 +213,12 @@ type AESCBCParams struct {
 	Algorithm
 
 	// Name should be set to AES-CBC.
-	Name string `json:"name"`
+	Name string `js:"name"`
 
 	// Iv holds (an ArrayBuffer, a TypedArray, or a DataView) the initialization vector.
 	// Must be 16 bytes, unpredictable, and preferably cryptographically random.
 	// However, it need not be secret (for example, it may be transmitted unencrypted along with the ciphertext).
-	Iv []byte `json:"iv"`
+	Iv []byte `js:"iv"`
 }
 
 // Encrypt encrypts the given plaintext using the AES-CBC algorithm, and returns the ciphertext.
@@ -317,7 +317,7 @@ type AESCTRParams struct {
 	//
 	// For example, if length is set to 64, then the first half of counter is
 	// the nonce and the second half is used for the counter.
-	Counter []byte `json:"counter"`
+	Counter []byte `js:"counter"`
 
 	// Length holds (a Number) the number of bits in the counter block that are used for the actual counter.
 	// The counter must be big enough that it doesn't wrap: if the message is n blocks and the counter is m bits long, then
@@ -325,7 +325,7 @@ type AESCTRParams struct {
 	//
 	// The NIST SP800-38A standard, which defines CTR, suggests that the counter should occupy half of the counter
 	// block (see Appendix B.2), so for AES it would be 64.
-	Length int `json:"length"`
+	Length int `js:"length"`
 }
 
 // Encrypt encrypts the given plaintext using the AES-CTR algorithm, and returns the ciphertext.
@@ -417,7 +417,7 @@ type AESGCMParams struct {
 	// Section 8.2 of the specification outlines methods for constructing IVs.
 	// Note that the IV does not have to be secret, just unique: so it is OK, for example, to
 	// transmit it in the clear alongside the encrypted message.
-	Iv []byte `json:"iv"`
+	Iv []byte `js:"iv"`
 
 	// AdditionalData (an ArrayBuffer, a TypedArray, or a DataView) contains additional data that will
 	// not be encrypted but will be authenticated along with the encrypted data.
@@ -431,7 +431,7 @@ type AESGCMParams struct {
 	//
 	// The additionalData property is optional and may be omitted without compromising the
 	// security of the encryption operation.
-	AdditionalData []byte `json:"additionalData"`
+	AdditionalData []byte `js:"additionalData"`
 
 	// TagLength (a Number) determines the size in bits of the authentication tag generated in
 	// the encryption operation and used for authentication in the corresponding decryption.
@@ -443,7 +443,7 @@ type AESGCMParams struct {
 	// in some applications: Appendix C of the specification provides additional guidance here.
 	//
 	// tagLength is optional and defaults to 128 if it is not specified.
-	TagLength bitLength `json:"tagLength"`
+	TagLength bitLength `js:"tagLength"`
 }
 
 // Encrypt encrypts the given plaintext using the AES-GCM algorithm, and returns the ciphertext.

--- a/webcrypto/algorithm.go
+++ b/webcrypto/algorithm.go
@@ -9,7 +9,7 @@ import (
 
 // Algorithm represents
 type Algorithm struct {
-	Name AlgorithmIdentifier `json:"name"`
+	Name AlgorithmIdentifier `js:"name"`
 }
 
 // AlgorithmIdentifier represents the name of an algorithm.

--- a/webcrypto/crypto.go
+++ b/webcrypto/crypto.go
@@ -15,8 +15,8 @@ import (
 type Crypto struct {
 	vu modules.VU
 
-	Subtle    *SubtleCrypto `json:"subtle"`
-	CryptoKey *CryptoKey    `json:"CryptoKey"`
+	Subtle    *SubtleCrypto `js:"subtle"`
+	CryptoKey *CryptoKey    `js:"CryptoKey"`
 }
 
 // GetRandomValues lets you get cryptographically strong random values.

--- a/webcrypto/elliptic_curve.go
+++ b/webcrypto/elliptic_curve.go
@@ -5,10 +5,10 @@ package webcrypto
 // key pair: that is, when the algorithm is identified as either of ECDSA or ECDH.
 type EcKeyImportParams struct {
 	// Name should be set to AlgorithmKindEcdsa or AlgorithmKindEcdh.
-	Name AlgorithmIdentifier `json:"name"`
+	Name AlgorithmIdentifier `js:"name"`
 
 	// NamedCurve holds (a String) the name of the elliptic curve to use.
-	NamedCurve EllipticCurveKind `json:"namedCurve"`
+	NamedCurve EllipticCurveKind `js:"namedCurve"`
 }
 
 // EllipticCurveKind represents the kind of elliptic curve that is being used.

--- a/webcrypto/errors.go
+++ b/webcrypto/errors.go
@@ -45,10 +45,10 @@ const (
 // Web Crypto API.
 type Error struct {
 	// Name contains one of the strings associated with an error name.
-	Name string `json:"name"`
+	Name string `js:"name"`
 
 	// Message represents message or description associated with the given error name.
-	Message string `json:"message"`
+	Message string `js:"message"`
 }
 
 // Error implements the `error` interface, so WebCryptoError are normal Go errors.

--- a/webcrypto/hmac.go
+++ b/webcrypto/hmac.go
@@ -20,14 +20,14 @@ type HMACKeyGenParams struct {
 	// Hash represents the name of the digest function to use. You can
 	// use any of the following: [Sha256], [Sha384],
 	// or [Sha512].
-	Hash Algorithm `json:"hash"`
+	Hash Algorithm `js:"hash"`
 
 	// Length holds (a Number) the length of the key, in bits.
 	// If this is omitted, the length of the key is equal to the block size
 	// of the hash function you have chosen.
 	// Unless you have a good reason to use a different length, omit
 	// use the default.
-	Length null.Int `json:"length"`
+	Length null.Int `js:"length"`
 }
 
 // newHMACKeyGenParams creates a new HMACKeyGenParams object, from the normalized
@@ -163,10 +163,10 @@ type HMACKeyAlgorithm struct {
 	KeyAlgorithm
 
 	// Hash represents the inner hash function to use.
-	Hash KeyAlgorithm `json:"hash"`
+	Hash KeyAlgorithm `js:"hash"`
 
 	// Length represents he length (in bits) of the key.
-	Length int64 `json:"length"`
+	Length int64 `js:"length"`
 }
 
 func exportHMACKey(ck *CryptoKey, format KeyFormat) ([]byte, error) {
@@ -209,14 +209,14 @@ type HMACImportParams struct {
 	// Hash represents the name of the digest function to use. You can
 	// use any of the following: [Sha256], [Sha384],
 	// or [Sha512].
-	Hash Algorithm `json:"hash"`
+	Hash Algorithm `js:"hash"`
 
 	// Length holds (a Number) the length of the key, in bits.
 	// If this is omitted, the length of the key is equal to the block size
 	// of the hash function you have chosen.
 	// Unless you have a good reason to use a different length, omit
 	// use the default.
-	Length null.Int `json:"length"`
+	Length null.Int `js:"length"`
 }
 
 // newHMACImportParams creates a new HMACImportParams object from the given

--- a/webcrypto/test_setup.go
+++ b/webcrypto/test_setup.go
@@ -36,6 +36,7 @@ func newTestSetup(t testing.TB) testSetup {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
 	rt := goja.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
 	// We compile the Web Platform testharness script into a goja.Program
 	harnessProgram, err := CompileFile("./tests/util", "testharness.js")

--- a/webcrypto/test_setup.go
+++ b/webcrypto/test_setup.go
@@ -36,7 +36,6 @@ func newTestSetup(t testing.TB) testSetup {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
 	rt := goja.New()
-	rt.SetFieldNameMapper(goja.TagFieldNameMapper("json", true))
 
 	// We compile the Web Platform testharness script into a goja.Program
 	harnessProgram, err := CompileFile("./tests/util", "testharness.js")


### PR DESCRIPTION
This PR contains a hot fix for #55 

It removes usage of the `goja.SetTagFieldMapper` function in the module code, and introduces builder helpers to create the javascript objects exposed by the module.
 