### PR TITLE
HMAC fix for the sign and verify

### DIFF
--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -266,7 +266,7 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data goja.Value) *goja.Promise {
 		// 10.
 		switch normalized.Name {
 		case HMAC:
-			keyAlgorithm, ok := ck.Algorithm.(HMACKeyAlgorithm)
+			keyAlgorithm, ok := ck.Algorithm.(hasHash)
 			if !ok {
 				reject(NewError(InvalidAccessError, "key algorithm does not describe a HMAC key"))
 				return
@@ -278,9 +278,9 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data goja.Value) *goja.Promise {
 				return
 			}
 
-			hashFn, err := keyAlgorithm.HashFn()
-			if err != nil {
-				reject(err)
+			hashFn, ok := getHashFn(keyAlgorithm.hash())
+			if !ok {
+				reject(NewError(NotSupportedError, "unsupported hash algorithm "+keyAlgorithm.hash()))
 				return
 			}
 
@@ -374,7 +374,7 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data goja.Value) *goja
 
 		switch normalizedAlgorithm.Name {
 		case HMAC:
-			keyAlgorithm, ok := ck.Algorithm.(HMACKeyAlgorithm)
+			keyAlgorithm, ok := ck.Algorithm.(hasHash)
 			if !ok {
 				reject(NewError(InvalidAccessError, "key algorithm does not describe a HMAC key"))
 				return
@@ -386,9 +386,9 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data goja.Value) *goja
 				return
 			}
 
-			hashFn, err := keyAlgorithm.HashFn()
-			if err != nil {
-				reject(err)
+			hashFn, ok := getHashFn(keyAlgorithm.hash())
+			if !ok {
+				reject(NewError(NotSupportedError, "unsupported hash algorithm "+keyAlgorithm.hash()))
 				return
 			}
 


### PR DESCRIPTION
# What?

This change fixes a degradation that happened after merging the https://github.com/grafana/xk6-webcrypto/pull/61

I found it while working on the ECDSA support, and it seems like ECDSA was also a reason why the test case was disabled https://github.com/grafana/xk6-webcrypto/issues/41. 

# Why?

Without the change our example erroring with:
```
./k6 run examples/sign_verify/sign-verify-hmac.js

INFO[0000] {"name":"InvalidAccessError","message":"key algorithm does not describe a HMAC key"}  source=console
```