### PR TITLE
Refactor WebCrypto to be tread safe: part 1

### DIFF
--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -130,69 +130,69 @@ func (sc *SubtleCrypto) Encrypt(algorithm, key, data goja.Value) *goja.Promise {
 // The `data` parameter should contain the data to be decrypted.
 func (sc *SubtleCrypto) Decrypt(algorithm, key, data goja.Value) *goja.Promise {
 	rt := sc.vu.Runtime()
-	promise, resolve, reject := promises.New(sc.vu)
 
-	// 2.
-	// We obtain a copy of the key data, because we might need to modify it.
-	ciphertext, err := exportArrayBuffer(rt, data)
-	if err != nil {
-		reject(err)
-		return promise
-	}
+	var (
+		ciphertext []byte
+		ck         CryptoKey
+		decrypter  EncryptDecrypter
+	)
 
-	// 3.
-	normalized, err := normalizeAlgorithm(rt, algorithm, OperationIdentifierDecrypt)
-	if err != nil {
-		reject(err)
-		return promise
-	}
-
-	var ck CryptoKey
-	if err = rt.ExportTo(key, &ck); err != nil {
-		reject(NewError(InvalidAccessError, "key argument does hold not a valid CryptoKey object"))
-		return promise
-	}
-
-	keyAlgorithmNameValue, err := traverseObject(rt, key.ToObject(rt), "algorithm", "name")
-	if err != nil {
-		reject(err)
-		return promise
-	}
-
-	// 8.
-	if normalized.Name != keyAlgorithmNameValue.String() {
-		reject(NewError(InvalidAccessError, "algorithm name does not match key algorithm name"))
-		return promise
-	}
-
-	decrypter, err := newEncryptDecrypter(rt, normalized, algorithm)
-	if err != nil {
-		reject(err)
-		return promise
-	}
-
-	go func() {
-		// 9.
-		if !ck.ContainsUsage(DecryptCryptoKeyUsage) {
-			reject(NewError(InvalidAccessError, "key does not contain the 'decrypt' usage"))
-			return
+	err := func() error {
+		var err error
+		ciphertext, err = exportArrayBuffer(rt, data)
+		if err != nil {
+			return err
 		}
 
-		var plaintext []byte
+		normalized, err := normalizeAlgorithm(rt, algorithm, OperationIdentifierDecrypt)
+		if err != nil {
+			return err
+		}
 
-		switch normalized.Name {
-		case AESCbc, AESCtr, AESGcm:
-			// 10.
-			plaintext, err = decrypter.Decrypt(ciphertext, ck)
+		if err = rt.ExportTo(key, &ck); err != nil {
+			return NewError(InvalidAccessError, "decrypt's key argument does hold not a valid CryptoKey object")
+		}
+
+		keyAlgorithmNameValue, err := traverseObject(rt, key.ToObject(rt), "algorithm", "name")
+		if err != nil {
+			return err
+		}
+
+		if normalized.Name != keyAlgorithmNameValue.String() {
+			return NewError(InvalidAccessError, "decrypt's algorithm name does not match key algorithm name")
+		}
+
+		decrypter, err = newEncryptDecrypter(rt, normalized, algorithm)
+		if err != nil {
+			return err
+		}
+
+		if !ck.ContainsUsage(DecryptCryptoKeyUsage) {
+			return NewError(InvalidAccessError, "decrypt's key does not contain the 'decrypt' usage")
+		}
+
+		return nil
+	}()
+
+	promise, resolve, reject := rt.NewPromise()
+	if err != nil {
+		reject(err)
+		return promise
+	}
+
+	callback := sc.vu.RegisterCallback()
+	go func() {
+		result, err := decrypter.Decrypt(ciphertext, ck)
+
+		callback(func() error {
 			if err != nil {
 				reject(err)
-				return
+				return nil //nolint:nilerr // we return nil to indicate that the error was handled
 			}
 
-			resolve(rt.NewArrayBuffer(plaintext))
-		default:
-			reject(NewError(NotSupportedError, fmt.Sprintf("unsupported algorithm %q", normalized.Name)))
-		}
+			resolve(rt.NewArrayBuffer(result))
+			return nil
+		})
 	}()
 
 	return promise

--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -36,7 +36,9 @@ type SubtleCrypto struct {
 // The `key` parameter should be a `CryptoKey` to be used for encryption.
 //
 // The `data` parameter should contain the data to be encryption.
-func (sc *SubtleCrypto) Encrypt(algorithm, key, data goja.Value) *goja.Promise {
+func (sc *SubtleCrypto) Encrypt( //nolint:dupl // we have two similar methods
+	algorithm, key, data goja.Value,
+) *goja.Promise {
 	rt := sc.vu.Runtime()
 
 	var (
@@ -127,7 +129,9 @@ func (sc *SubtleCrypto) Encrypt(algorithm, key, data goja.Value) *goja.Promise {
 // The `key` parameter should be a `CryptoKey` to be used for decryption.
 //
 // The `data` parameter should contain the data to be decrypted.
-func (sc *SubtleCrypto) Decrypt(algorithm, key, data goja.Value) *goja.Promise {
+func (sc *SubtleCrypto) Decrypt( //nolint:dupl // we have two similar methods
+	algorithm, key, data goja.Value,
+) *goja.Promise {
 	rt := sc.vu.Runtime()
 
 	var (


### PR DESCRIPTION
# What?

This change centralizes and unifies logic and ensures that runtime (`tr`) isn't used outside the event loop.

I also removed references to WebCrypto steps, like (`1.`, `2.`, etc.) since the issue is that for different algorithms, they could mean different steps, which could confuse future maintainers.

Splitting the PR into the parts to make it smaller.

# Why?

Updates #71