### PR TITLE
Handling panics in encrypt/decrypt

### DIFF
--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -94,7 +94,16 @@ func (sc *SubtleCrypto) Encrypt( //nolint:dupl // we have two similar methods
 
 	callback := sc.vu.RegisterCallback()
 	go func() {
-		result, err := encrypter.Encrypt(plaintext, ck)
+		result, err := func() (result []byte, err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = NewError(OperationError, fmt.Sprintf("an unexpected error during encrypting happened: %s", r))
+				}
+			}()
+
+			result, err = encrypter.Encrypt(plaintext, ck)
+			return
+		}()
 
 		callback(func() error {
 			if err != nil {
@@ -186,7 +195,16 @@ func (sc *SubtleCrypto) Decrypt( //nolint:dupl // we have two similar methods
 
 	callback := sc.vu.RegisterCallback()
 	go func() {
-		result, err := decrypter.Decrypt(ciphertext, ck)
+		result, err := func() (result []byte, err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = NewError(OperationError, fmt.Sprintf("an unexpected error during decrypting happened: %s", r))
+				}
+			}()
+
+			result, err = decrypter.Decrypt(ciphertext, ck)
+			return
+		}()
 
 		callback(func() error {
 			if err != nil {

--- a/webcrypto/tests/cmd_run_test.go
+++ b/webcrypto/tests/cmd_run_test.go
@@ -99,6 +99,25 @@ func TestExamplesInputOutput(t *testing.T) {
 	}
 }
 
+func TestHandlePanic(t *testing.T) {
+	t.Parallel()
+
+	script, err := os.ReadFile("handle-panic.js") //nolint:forbidigo // it's a test case
+	require.NoError(t, err)
+
+	ts := getSingleFileTestState(t, string(script), []string{"-v", "--log-output=stdout"}, 0)
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+
+	assert.Contains(t, stdout, "1 complete and 0 interrupted iterations")
+	// We expect the panic message to be printed
+	assert.Contains(t, stdout, "Uncaught")
+
+	assert.Empty(t, ts.Stderr.String())
+}
+
 func getFiles(t *testing.T, path string) []string {
 	t.Helper()
 

--- a/webcrypto/tests/handle-panic.js
+++ b/webcrypto/tests/handle-panic.js
@@ -1,0 +1,40 @@
+// this example demonstrates how to handle panic in the decrypt function
+// we intentionally cut transmittedData from 12 to the end, so it will panic
+// the panic will be caught
+import { crypto } from "k6/experimental/webcrypto";
+
+export default async function () {
+  const keyData = new Uint8Array([
+    7, 152, 164, 45, 255, 169, 164, 66, 164, 163, 20, 197, 194, 223, 48, 213,
+    93, 115, 173, 86, 215, 81, 128, 188, 45, 237, 156, 92, 163, 197, 248, 114,
+  ]);
+
+  const transmittedData = new Uint8Array([
+    167, 9, 89, 202, 97, 13, 137, 77, 223, 24, 226, 161, 225, 228, 121, 248,
+    181, 4, 25, 202, 215, 230, 193, 94, 143, 77, 187, 231, 84, 3, 198, 75, 22,
+    211, 83, 101, 241, 159, 117, 124, 155, 229, 244, 173, 58, 149, 57, 18,
+  ]);
+
+  const iv = new Uint8Array(transmittedData.slice(0, 16));
+
+  // we intentionally cut incorrectly transmittedData from 12 to the end
+  const encryptedData = new Uint8Array(transmittedData.slice(12));
+
+  const importedKey = await crypto.subtle.importKey(
+    "raw",
+    keyData,
+    { name: "AES-CBC", length: "256" },
+    true,
+    ["encrypt", "decrypt"]
+  );
+
+  // if we pass such transmittedData to decrypt function, it will panic
+  await crypto.subtle.decrypt(
+    {
+      name: "AES-CBC",
+      iv: iv,
+    },
+    importedKey,
+    encryptedData
+  );
+}


### PR DESCRIPTION
# What?

As grafana/k6#4258 showcased, there could be cases where using some specific methods (even from Golang's standard library) could lead to panic.

This PR introduces a way to handle such panics and "convert" them into regular errors. If the approach makes sense, we could use all of the main webcrypto methods. Later on, some generic abstraction could be considered to make all web crypto methods bootstrap free.

# Why?

Panics terminate k6 whenever. For such cases, it's just an application-level error.

Closes grafana/k6#4258