### PR TITLE
Omit funlen linter for ExportKey

### DIFF
--- a/webcrypto/subtle_crypto.go
+++ b/webcrypto/subtle_crypto.go
@@ -865,7 +865,7 @@ func (sc *SubtleCrypto) ImportKey( //nolint:funlen // we have a lot of error han
 //
 // The `format` parameter identifies the format of the key data.
 // The `key` parameter is the key to export, as a CryptoKey object.
-func (sc *SubtleCrypto) ExportKey(
+func (sc *SubtleCrypto) ExportKey( //nolint:funlen // we have a lot of error handling
 	format KeyFormat,
 	key sobek.Value,
 ) (*sobek.Promise, error) {


### PR DESCRIPTION
# What?

Omit linter message, caused by latest merges

# Why?

To make the pipeline green again